### PR TITLE
exposed pairiterationThreshold

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -465,7 +465,7 @@
       var c1b = c1.bbox(),
           c2b = c2.bbox(),
           r = 100000;
-      if(c1b.x.size + c1b.y.size < pairiterationThreshold && c2b.x.size + c2b.y.size < pairiterationThreshold) {
+      if(c1b.x.size + c1b.y.size < utils.pairiterationThreshold && c2b.x.size + c2b.y.size < utils.pairiterationThreshold) {
         return [ ((r * (c1._t1+c1._t2)/2)|0)/r + "/" + ((r * (c2._t1+c2._t2)/2)|0)/r ];
       }
       var cc1 = c1.split(0.5),

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -459,12 +459,13 @@
       if(bbox.z) { bbox.z.size = bbox.z.max - bbox.z.min; }
     },
 
+    pairiterationThreshold: 0.5,
+    
     pairiteration: function(c1,c2) {
       var c1b = c1.bbox(),
           c2b = c2.bbox(),
-          r = 100000,
-          threshold = 0.5;
-      if(c1b.x.size + c1b.y.size < threshold && c2b.x.size + c2b.y.size < threshold) {
+          r = 100000;
+      if(c1b.x.size + c1b.y.size < pairiterationThreshold && c2b.x.size + c2b.y.size < pairiterationThreshold) {
         return [ ((r * (c1._t1+c1._t2)/2)|0)/r + "/" + ((r * (c2._t1+c2._t2)/2)|0)/r ];
       }
       var cc1 = c1.split(0.5),


### PR DESCRIPTION
I was able to get closer tolerances of Bezier.intersects(Bezier) by modifying the threshold value. So I thought it would be nice if the threshold was settable by the developer. Instead of patching it through every referring caller to pairiteration(), I made it a local global.