### PR TITLE
Added curve intersection threshold as a parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -837,7 +837,7 @@
       </section>
 
       <section>
-        <h1>.intersects() and .intersects(line) and .intersects(curve)</h1>
+        <h1>.intersects(), .intersects(line), .intersects(curve), and .intersects(curve, curveIntersectionThreshold)</h1>
 
         <h2>.intersects()</h2>
 

--- a/index.html
+++ b/index.html
@@ -791,7 +791,7 @@
       </section>
 
       <section>
-        <h1>.outlineshapes(d)</h1>
+        <h1>.outlineshapes(d), .outlineshapes(d1, d2), and .outlineshapes(d1, d2, curveIntersectionThreshold)</h1>
 
         <figures>
           <figure class="quadratic"><script type="text/beziercode">
@@ -824,9 +824,16 @@
         <p>This generates a curve's outline as a series of shapes, rather than as a path sequence. Each shape is
           an object <code>{startcap: (bezier), forward: (bezier), endcap: (bezier), back: (bezier)}</code>.
           Additionally, each cap has a <code>.virtual</code> attribute to indicate whether it a true cap for
-          the original curve's outline, or an intermediary cap somewhere inside the collection of outline shapes.
-          Finally, shapes have an <code>.intersects(othershape)</code> function for finding intersections
-          between shapes rather than between individual curves.</p>
+          the original curve's outline, or an intermediary cap somewhere inside the collection of outline shapes.</p>
+
+        <p>When only one distance value is given, the shape's curve's outlines are generated at distance <code>d</code> on both
+          the normal and anti-normal. If two distance values are given, the shape's curve's outlines are generated at distance
+          <code>d1</code> on along the normal, and <code>d2</code> along the anti-normal.</p>
+
+        <p>Finally, shapes have an <code>.intersections(othershape)</code> function for finding intersections
+          between shapes rather than between individual curves. If <code>curveIntersectionThreshold</code> is provided, it
+          will be used for precision of <a href="#curvetocurveintersection">curve to curve intersections</a>.</p>
+
       </section>
 
       <section>
@@ -900,8 +907,10 @@
           not standard Cardano's algorithm for solving the cubic root function.</p>
       </section>
 
+      <a name="curvetocurveintersection"></a>
+      
       <section>
-        <h2>.intersects(curve)</h2>
+        <h2>.intersects(curve) and .intersects(curve, curveIntersectionThreshold)</h2>
 
         <figures>
           <figure class="quadratic"><script type="text/beziercode">
@@ -946,7 +955,8 @@
         "homes in" on the actual intersections, such that with infinite divisions, we can get an arbitrarily
         close approximation of the <code>t</code> values involved. Thankfully, repeating the process a low number
         of steps is generally good enough to get reliable values (typically 10 steps yields more than acceptable
-        precision).</p>
+        precision). When <code>curveIntersectionThreshold</code> is provided, this will be used for bounding box 
+        comparisons in x and y dimensions so that precision can be specified, otherwise a default value of .5 will be used.</p>
 
       </section>
     </main>

--- a/lib/bezier.js
+++ b/lib/bezier.js
@@ -700,7 +700,7 @@
       return shapes;
     },
     intersects: function(curve, curveIntersectionThreshold) {
-      if(!curve) return this.selfintersects();
+      if(!curve) return this.selfintersects(curveIntersectionThreshold);
       if(curve.p1 && curve.p2) {
         return this.lineIntersects(curve);
       }
@@ -718,7 +718,7 @@
         return utils.between(p.x, mx, MX) && utils.between(p.y, my, MY);
       });
     },
-    selfintersects: function() {
+    selfintersects: function(threshold) {
       var reduced = this.reduce();
       // "simple" curves cannot intersect with their direct
       // neighbour, so for each segment X we check whether
@@ -727,7 +727,7 @@
       for(i=0; i<len; i++) {
         left = reduced.slice(i,i+1);
         right = reduced.slice(i+2);
-        result = this.curveintersects(left, right, null);
+        result = this.curveintersects(left, right, threshold);
         results = results.concat( result );
       }
       return results;

--- a/lib/bezier.js
+++ b/lib/bezier.js
@@ -718,7 +718,7 @@
         return utils.between(p.x, mx, MX) && utils.between(p.y, my, MY);
       });
     },
-    selfintersects: function(threshold) {
+    selfintersects: function(curveIntersectionThreshold) {
       var reduced = this.reduce();
       // "simple" curves cannot intersect with their direct
       // neighbour, so for each segment X we check whether
@@ -727,12 +727,12 @@
       for(i=0; i<len; i++) {
         left = reduced.slice(i,i+1);
         right = reduced.slice(i+2);
-        result = this.curveintersects(left, right, threshold);
+        result = this.curveintersects(left, right, curveIntersectionThreshold);
         results = results.concat( result );
       }
       return results;
     },
-    curveintersects: function(c1, c2, threshold) {
+    curveintersects: function(c1, c2, curveIntersectionThreshold) {
       var pairs = [];
       // step 1: pair off any overlapping segments
       c1.forEach(function(l) {
@@ -745,7 +745,7 @@
       // step 2: for each pairing, run through the convergence algorithm.
       var intersections = [];
       pairs.forEach(function(pair) {
-        var result = utils.pairiteration(pair.left, pair.right, threshold);
+        var result = utils.pairiteration(pair.left, pair.right, curveIntersectionThreshold);
         if(result.length > 0) {
           intersections = intersections.concat(result);
         }

--- a/lib/bezier.js
+++ b/lib/bezier.js
@@ -687,25 +687,25 @@
 
       return new PolyBezier(segments);
     },
-    outlineshapes: function(d1,d2) {
+    outlineshapes: function(d1, d2, curveIntersectionThreshold) {
       d2 = d2 || d1;
       var outline = this.outline(d1,d2).curves;
       var shapes = [];
       for(var i=1, len=outline.length; i < len/2; i++) {
-        var shape = utils.makeshape(outline[i], outline[len-i]);
+        var shape = utils.makeshape(outline[i], outline[len-i], curveIntersectionThreshold);
         shape.startcap.virtual = (i > 1);
         shape.endcap.virtual = (i < len/2-1);
         shapes.push(shape);
       }
       return shapes;
     },
-    intersects: function(curve) {
+    intersects: function(curve, curveIntersectionThreshold) {
       if(!curve) return this.selfintersects();
       if(curve.p1 && curve.p2) {
         return this.lineIntersects(curve);
       }
       if(curve instanceof Bezier) { curve = curve.reduce(); }
-      return this.curveintersects(this.reduce(), curve);
+      return this.curveintersects(this.reduce(), curve, curveIntersectionThreshold);
     },
     lineIntersects: function(line) {
       var mx = min(line.p1.x, line.p2.x),
@@ -727,12 +727,12 @@
       for(i=0; i<len; i++) {
         left = reduced.slice(i,i+1);
         right = reduced.slice(i+2);
-        result = this.curveintersects(left, right);
+        result = this.curveintersects(left, right, null);
         results = results.concat( result );
       }
       return results;
     },
-    curveintersects: function(c1,c2) {
+    curveintersects: function(c1, c2, threshold) {
       var pairs = [];
       // step 1: pair off any overlapping segments
       c1.forEach(function(l) {
@@ -745,7 +745,7 @@
       // step 2: for each pairing, run through the convergence algorithm.
       var intersections = [];
       pairs.forEach(function(pair) {
-        var result = utils.pairiteration(pair.left, pair.right);
+        var result = utils.pairiteration(pair.left, pair.right, threshold);
         if(result.length > 0) {
           intersections = intersections.concat(result);
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -242,7 +242,7 @@
       }
     },
 
-    shapeintersections: function(s1, bbox1, s2, bbox2) {
+    shapeintersections: function(s1, bbox1, s2, bbox2, curveIntersectionThreshold) {
       if(!utils.bboxoverlap(bbox1, bbox2)) return [];
       var intersections = [];
       var a1 = [s1.startcap, s1.forward, s1.back, s1.endcap];
@@ -251,7 +251,7 @@
         if(l1.virtual) return;
         a2.forEach(function(l2) {
           if(l2.virtual) return;
-          var iss = l1.intersects(l2);
+          var iss = l1.intersects(l2, curveIntersectionThreshold);
           if(iss.length>0) {
             iss.c1 = l1;
             iss.c2 = l2;
@@ -264,7 +264,7 @@
       return intersections;
     },
 
-    makeshape: function(forward, back) {
+    makeshape: function(forward, back, curveIntersectionThreshold) {
       var bpl = back.points.length;
       var fpl = forward.points.length;
       var start  = utils.makeline(back.points[bpl-1], forward.points[0]);
@@ -278,7 +278,7 @@
       };
       var self = utils;
       shape.intersections = function(s2) {
-        return self.shapeintersections(shape,shape.bbox,s2,s2.bbox);
+        return self.shapeintersections(shape,shape.bbox,s2,s2.bbox, curveIntersectionThreshold);
       };
       return shape;
     },
@@ -459,11 +459,11 @@
       if(bbox.z) { bbox.z.size = bbox.z.max - bbox.z.min; }
     },
 
-    pairiteration: function(c1,c2) {
+    pairiteration: function(c1, c2, curveIntersectionThreshold) {
       var c1b = c1.bbox(),
           c2b = c2.bbox(),
           r = 100000,
-          threshold = 0.5;
+          threshold = curveIntersectionThreshold || 0.5;
       if(c1b.x.size + c1b.y.size < threshold && c2b.x.size + c2b.y.size < threshold) {
         return [ ((r * (c1._t1+c1._t2)/2)|0)/r + "/" + ((r * (c2._t1+c2._t2)/2)|0)/r ];
       }
@@ -481,7 +481,7 @@
       if(pairs.length === 0) return results;
       pairs.forEach(function(pair) {
         results = results.concat(
-          utils.pairiteration(pair.left, pair.right)
+          utils.pairiteration(pair.left, pair.right, threshold)
         );
       })
       results = results.filter(function(v,i) {


### PR DESCRIPTION
I was able to get closer tolerances of Bezier.intersects(Bezier) by modifying the threshold value. So I've made it an optional parameter. Threaded this value through all referring calls to utils.pairiteration, which means that it is now an optional parameter to:
* Bezier.outlineshapes
* Bezier.intersects
* Bezier.curveintersects
* Bezier.selfintersects
* utils.shapeintersections
* utils.makeshape
* utils.pairiteration
