### PR TITLE
Fix missing inflection point on symmetric curves

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -419,7 +419,14 @@
           v2 = 18 * (3*a - b - 3*c),
           v3 = 18 * (c - a);
 
-      if (utils.approximately(v1,0)) return [];
+      if (utils.approximately(v1,0)){
+        if(v2!=0){
+          var t = -v3/v2;
+          if (0 <= t && t <= 1)
+             return [t];
+        }
+        return [];
+      }
 
       var trm = v2*v2 - 4*v1*v3,
           sq = Math.sqrt(trm),


### PR DESCRIPTION
When the curve is symmetric, the lib returns no inflection point even if there is one.
`(new Bezier(100,100 , 100,150 , 200,150, 200,200)).inflections();`

When solving an equation of type `a*t² + b*t + c = 0`, the code returns no solution if `a==0` but this is not correct. We then have `b*t + c = 0` which may have one solution `-c/b` in case `b!=0`.

It may be good to check if this error is present elsewhere in the codebase.

Thanks for your bezier explanations, it's very useful !