### PR TITLE
Do not allow interval.end value to exceed 1

### DIFF
--- a/lib/bezier.js
+++ b/lib/bezier.js
@@ -817,7 +817,7 @@
               break;
             }
             // if not, move it up by half the iteration distance
-            e = e + (e-s)/2;
+            e = Math.min(e + (e-s)/2, 1);
           }
 
           // this is a bad arc: we need to move 'e' down to find a good arc


### PR DESCRIPTION
I ran into a case when getting .arcs() that the t value exceeded 1:

new Bezier([25.308000000000003,10.260000000000001,25.848000000000002,10.728000000000001,25.848000000000002,11.304000000000002]).arcs(0.0012143080752705958)[1].interval.end

1.078125

In any case, it seemed safe to clamp e to 1 with Math.min.