### PR TITLE
Add CDN links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ or read the souce (`./lib` for the library code, start at `index.js`).
 
 `npm install bezier-js`
 
+## CDN usage
+
+`<script src="https://cdn.jsdelivr.net/npm/bezier-js@2/lib/bezier.js"></script>`
+
 ## Working on the code
 
 To rebuild, simply use `npm test`, which runs both the build and tests (which aren't very


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/bezier-js) to your readme, so that people can use files directly without downloading them. jsDelivr is also the fastest opensource CDN available and built specifically for production usage.