### PR TITLE
:wrench: Added rimraf to dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "chai": "^3.2.0",
     "chai-stats": "^0.3.0",
     "mkdirp": "^0.5.1",
+    "rimraf": "2.6.2",
     "uglify": "^0.1.1",
     "uglify-js": "^2.4.17",
     "webpack": "^1.12.13"


### PR DESCRIPTION
Rimraf is used in the build script, but is not part of the dev
dependencies. Users who don't have it installed globally will
get an error when building this project.

By adding it as a dev dependency, things should just work.