### PR TITLE
:rotating_light: Removed circular dependency

### DIFF
--- a/lib/bezier.js
+++ b/lib/bezier.js
@@ -22,6 +22,24 @@
 
   // quite needed
   var utils = require("./utils.js");
+  utils.makeline = function(p1, p2) {
+    var x1 = p1.x,
+      y1 = p1.y,
+      x2 = p2.x,
+      y2 = p2.y,
+      dx = (x2 - x1) / 3,
+      dy = (y2 - y1) / 3;
+    return new Bezier(
+      x1,
+      y1,
+      x1 + dx,
+      y1 + dy,
+      x1 + 2 * dx,
+      y1 + 2 * dy,
+      x2,
+      y2
+    );
+  }
 
   // only used for outlines atm.
   var PolyBezier = require("./poly-bezier.js");

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -244,26 +244,6 @@
       return utils.lli4(v1, v1.c, v2, v2.c);
     },
 
-    makeline: function(p1, p2) {
-      var Bezier = require("./bezier");
-      var x1 = p1.x,
-        y1 = p1.y,
-        x2 = p2.x,
-        y2 = p2.y,
-        dx = (x2 - x1) / 3,
-        dy = (y2 - y1) / 3;
-      return new Bezier(
-        x1,
-        y1,
-        x1 + dx,
-        y1 + dy,
-        x1 + 2 * dx,
-        y1 + 2 * dy,
-        x2,
-        y2
-      );
-    },
-
     findbbox: function(sections) {
       var mx = nMax,
         my = nMax,


### PR DESCRIPTION
When compiling my project with Rollup.js, it throws this warning:

```
(!) Circular dependency: node_modules/bezier-js/lib/bezier.js
  -> node_modules/bezier-js/lib/utils.js
  -> node_modules/bezier-js/lib/bezier.js
```

So bezier needs utils, which needs bezier.

I had a look, and the only method in utils that needs bezier is
the `makeline()` method.

I've removed it from utils.js, and instead added it to utils once
imported in bezier.js.

This avoid the `require` statement, but I guess it's kinda hackish.

I'm certain there's a better way to fix this, but I wanted to (try
to) be a bit more helpful than open an issue. Hence this PR.

Note that this does not make any functional changes to the code.
Nor is the issue that it fixes a *real* problem. It would just be
nice to avoid the circular dependency and suppress that warning.