### PR TITLE
Fix offsetting bezier when some curves are linear

### DIFF
--- a/lib/bezier.js
+++ b/lib/bezier.js
@@ -550,6 +550,9 @@
       }
       var reduced = this.reduce();
       return reduced.map(function(s) {
+        if (s._linear) {
+          return s.offset(t)[0];
+        }
         return s.scale(t);
       });
     },


### PR DESCRIPTION
offset fails when after reducing, a subcurve turns out to be linear. In that case, scale() fails as the intersection of the normals of the endpoints does not exist. Revert to linear offset for that curve.