### PR TITLE
hybrid esm/cjs package distribution

### DIFF
--- a/dist/cjs/bezier.js
+++ b/dist/cjs/bezier.js
@@ -1,0 +1,1031 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.Bezier = void 0;
+
+var _utils = require("./utils.js");
+
+var _polyBezier = require("./poly-bezier.js");
+
+var _svgToBeziers = require("./svg-to-beziers.js");
+
+/**
+  A javascript Bezier curve library by Pomax.
+
+  Based on http://pomax.github.io/bezierinfo
+
+  This code is MIT licensed.
+**/
+// math-inlining.
+const {
+  abs,
+  min,
+  max,
+  cos,
+  sin,
+  acos,
+  sqrt
+} = Math;
+const pi = Math.PI; // a zero coordinate, which is surprisingly useful
+
+const ZERO = {
+  x: 0,
+  y: 0,
+  z: 0
+};
+/**
+ * Bezier curve constructor.
+ *
+ * ...docs pending...
+ */
+
+class Bezier {
+  constructor(coords) {
+    let args = coords && coords.forEach ? coords : Array.from(arguments).slice();
+    let coordlen = false;
+
+    if (typeof args[0] === "object") {
+      coordlen = args.length;
+      const newargs = [];
+      args.forEach(function (point) {
+        ["x", "y", "z"].forEach(function (d) {
+          if (typeof point[d] !== "undefined") {
+            newargs.push(point[d]);
+          }
+        });
+      });
+      args = newargs;
+    }
+
+    let higher = false;
+    const len = args.length;
+
+    if (coordlen) {
+      if (coordlen > 4) {
+        if (arguments.length !== 1) {
+          throw new Error("Only new Bezier(point[]) is accepted for 4th and higher order curves");
+        }
+
+        higher = true;
+      }
+    } else {
+      if (len !== 6 && len !== 8 && len !== 9 && len !== 12) {
+        if (arguments.length !== 1) {
+          throw new Error("Only new Bezier(point[]) is accepted for 4th and higher order curves");
+        }
+      }
+    }
+
+    const _3d = this._3d = !higher && (len === 9 || len === 12) || coords && coords[0] && typeof coords[0].z !== "undefined";
+
+    const points = this.points = [];
+
+    for (let idx = 0, step = _3d ? 3 : 2; idx < len; idx += step) {
+      var point = {
+        x: args[idx],
+        y: args[idx + 1]
+      };
+
+      if (_3d) {
+        point.z = args[idx + 2];
+      }
+
+      points.push(point);
+    }
+
+    const order = this.order = points.length - 1;
+    const dims = this.dims = ["x", "y"];
+    if (_3d) dims.push("z");
+    this.dimlen = dims.length;
+
+    const aligned = _utils.utils.align(points, {
+      p1: points[0],
+      p2: points[order]
+    });
+
+    this._linear = !aligned.some(p => abs(p.y) > 0.0001);
+    this._lut = [];
+    this._t1 = 0;
+    this._t2 = 1;
+    this.update();
+  }
+
+  static SVGtoBeziers(d) {
+    return (0, _svgToBeziers.convertPath)(Bezier, d);
+  }
+
+  static quadraticFromPoints(p1, p2, p3, t) {
+    if (typeof t === "undefined") {
+      t = 0.5;
+    } // shortcuts, although they're really dumb
+
+
+    if (t === 0) {
+      return new Bezier(p2, p2, p3);
+    }
+
+    if (t === 1) {
+      return new Bezier(p1, p2, p2);
+    } // real fitting.
+
+
+    const abc = Bezier.getABC(2, p1, p2, p3, t);
+    return new Bezier(p1, abc.A, p3);
+  }
+
+  static cubicFromPoints(S, B, E, t, d1) {
+    if (typeof t === "undefined") {
+      t = 0.5;
+    }
+
+    const abc = Bezier.getABC(3, S, B, E, t);
+
+    if (typeof d1 === "undefined") {
+      d1 = _utils.utils.dist(B, abc.C);
+    }
+
+    const d2 = d1 * (1 - t) / t;
+
+    const selen = _utils.utils.dist(S, E),
+          lx = (E.x - S.x) / selen,
+          ly = (E.y - S.y) / selen,
+          bx1 = d1 * lx,
+          by1 = d1 * ly,
+          bx2 = d2 * lx,
+          by2 = d2 * ly; // derivation of new hull coordinates
+
+
+    const e1 = {
+      x: B.x - bx1,
+      y: B.y - by1
+    },
+          e2 = {
+      x: B.x + bx2,
+      y: B.y + by2
+    },
+          A = abc.A,
+          v1 = {
+      x: A.x + (e1.x - A.x) / (1 - t),
+      y: A.y + (e1.y - A.y) / (1 - t)
+    },
+          v2 = {
+      x: A.x + (e2.x - A.x) / t,
+      y: A.y + (e2.y - A.y) / t
+    },
+          nc1 = {
+      x: S.x + (v1.x - S.x) / t,
+      y: S.y + (v1.y - S.y) / t
+    },
+          nc2 = {
+      x: E.x + (v2.x - E.x) / (1 - t),
+      y: E.y + (v2.y - E.y) / (1 - t)
+    }; // ...done
+
+    return new Bezier(S, nc1, nc2, E);
+  }
+
+  static getUtils() {
+    return _utils.utils;
+  }
+
+  getUtils() {
+    return Bezier.getUtils();
+  }
+
+  static get PolyBezier() {
+    return _polyBezier.PolyBezier;
+  }
+
+  valueOf() {
+    return this.toString();
+  }
+
+  toString() {
+    return _utils.utils.pointsToString(this.points);
+  }
+
+  toSVG() {
+    if (this._3d) return false;
+    const p = this.points,
+          x = p[0].x,
+          y = p[0].y,
+          s = ["M", x, y, this.order === 2 ? "Q" : "C"];
+
+    for (let i = 1, last = p.length; i < last; i++) {
+      s.push(p[i].x);
+      s.push(p[i].y);
+    }
+
+    return s.join(" ");
+  }
+
+  setRatios(ratios) {
+    if (ratios.length !== this.points.length) {
+      throw new Error("incorrect number of ratio values");
+    }
+
+    this.ratios = ratios;
+    this._lut = []; //  invalidate any precomputed LUT
+  }
+
+  verify() {
+    const print = this.coordDigest();
+
+    if (print !== this._print) {
+      this._print = print;
+      this.update();
+    }
+  }
+
+  coordDigest() {
+    return this.points.map(function (c, pos) {
+      return "" + pos + c.x + c.y + (c.z ? c.z : 0);
+    }).join("");
+  }
+
+  update() {
+    // invalidate any precomputed LUT
+    this._lut = [];
+    this.dpoints = _utils.utils.derive(this.points, this._3d);
+    this.computedirection();
+  }
+
+  computedirection() {
+    const points = this.points;
+
+    const angle = _utils.utils.angle(points[0], points[this.order], points[1]);
+
+    this.clockwise = angle > 0;
+  }
+
+  length() {
+    return _utils.utils.length(this.derivative.bind(this));
+  }
+
+  static getABC(order = 2, S, B, E, t = 0.5) {
+    const u = _utils.utils.projectionratio(t, order),
+          um = 1 - u,
+          C = {
+      x: u * S.x + um * E.x,
+      y: u * S.y + um * E.y
+    },
+          s = _utils.utils.abcratio(t, order),
+          A = {
+      x: B.x + (B.x - C.x) / s,
+      y: B.y + (B.y - C.y) / s
+    };
+
+    return {
+      A,
+      B,
+      C,
+      S,
+      E
+    };
+  }
+
+  getABC(t, B) {
+    B = B || this.get(t);
+    let S = this.points[0];
+    let E = this.points[this.order];
+    return Bezier.getABC(this.order, S, B, E, t);
+  }
+
+  getLUT(steps) {
+    this.verify();
+    steps = steps || 100;
+
+    if (this._lut.length === steps) {
+      return this._lut;
+    }
+
+    this._lut = []; // We want a range from 0 to 1 inclusive, so
+    // we decrement and then use <= rather than <:
+
+    steps--;
+
+    for (let i = 0, p, t; i < steps; i++) {
+      t = i / (steps - 1);
+      p = this.compute(t);
+      p.t = t;
+
+      this._lut.push(p);
+    }
+
+    return this._lut;
+  }
+
+  on(point, error) {
+    error = error || 5;
+    const lut = this.getLUT(),
+          hits = [];
+
+    for (let i = 0, c, t = 0; i < lut.length; i++) {
+      c = lut[i];
+
+      if (_utils.utils.dist(c, point) < error) {
+        hits.push(c);
+        t += i / lut.length;
+      }
+    }
+
+    if (!hits.length) return false;
+    return t /= hits.length;
+  }
+
+  project(point) {
+    // step 1: coarse check
+    const LUT = this.getLUT(),
+          l = LUT.length - 1,
+          closest = _utils.utils.closest(LUT, point),
+          mpos = closest.mpos,
+          t1 = (mpos - 1) / l,
+          t2 = (mpos + 1) / l,
+          step = 0.1 / l; // step 2: fine check
+
+
+    let mdist = closest.mdist,
+        t = t1,
+        ft = t,
+        p;
+    mdist += 1;
+
+    for (let d; t < t2 + step; t += step) {
+      p = this.compute(t);
+      d = _utils.utils.dist(point, p);
+
+      if (d < mdist) {
+        mdist = d;
+        ft = t;
+      }
+    }
+
+    ft = ft < 0 ? 0 : ft > 1 ? 1 : ft;
+    p = this.compute(ft);
+    p.t = ft;
+    p.d = mdist;
+    return p;
+  }
+
+  get(t) {
+    return this.compute(t);
+  }
+
+  point(idx) {
+    return this.points[idx];
+  }
+
+  compute(t) {
+    if (this.ratios) {
+      return _utils.utils.computeWithRatios(t, this.points, this.ratios, this._3d);
+    }
+
+    return _utils.utils.compute(t, this.points, this._3d, this.ratios);
+  }
+
+  raise() {
+    const p = this.points,
+          np = [p[0]],
+          k = p.length;
+
+    for (let i = 1, pi, pim; i < k; i++) {
+      pi = p[i];
+      pim = p[i - 1];
+      np[i] = {
+        x: (k - i) / k * pi.x + i / k * pim.x,
+        y: (k - i) / k * pi.y + i / k * pim.y
+      };
+    }
+
+    np[k] = p[k - 1];
+    return new Bezier(np);
+  }
+
+  derivative(t) {
+    return _utils.utils.compute(t, this.dpoints[0]);
+  }
+
+  dderivative(t) {
+    return _utils.utils.compute(t, this.dpoints[1]);
+  }
+
+  align() {
+    let p = this.points;
+    return new Bezier(_utils.utils.align(p, {
+      p1: p[0],
+      p2: p[p.length - 1]
+    }));
+  }
+
+  curvature(t) {
+    return _utils.utils.curvature(t, this.dpoints[0], this.dpoints[1], this._3d);
+  }
+
+  inflections() {
+    return _utils.utils.inflections(this.points);
+  }
+
+  normal(t) {
+    return this._3d ? this.__normal3(t) : this.__normal2(t);
+  }
+
+  __normal2(t) {
+    const d = this.derivative(t);
+    const q = sqrt(d.x * d.x + d.y * d.y);
+    return {
+      x: -d.y / q,
+      y: d.x / q
+    };
+  }
+
+  __normal3(t) {
+    // see http://stackoverflow.com/questions/25453159
+    const r1 = this.derivative(t),
+          r2 = this.derivative(t + 0.01),
+          q1 = sqrt(r1.x * r1.x + r1.y * r1.y + r1.z * r1.z),
+          q2 = sqrt(r2.x * r2.x + r2.y * r2.y + r2.z * r2.z);
+    r1.x /= q1;
+    r1.y /= q1;
+    r1.z /= q1;
+    r2.x /= q2;
+    r2.y /= q2;
+    r2.z /= q2; // cross product
+
+    const c = {
+      x: r2.y * r1.z - r2.z * r1.y,
+      y: r2.z * r1.x - r2.x * r1.z,
+      z: r2.x * r1.y - r2.y * r1.x
+    };
+    const m = sqrt(c.x * c.x + c.y * c.y + c.z * c.z);
+    c.x /= m;
+    c.y /= m;
+    c.z /= m; // rotation matrix
+
+    const R = [c.x * c.x, c.x * c.y - c.z, c.x * c.z + c.y, c.x * c.y + c.z, c.y * c.y, c.y * c.z - c.x, c.x * c.z - c.y, c.y * c.z + c.x, c.z * c.z]; // normal vector:
+
+    const n = {
+      x: R[0] * r1.x + R[1] * r1.y + R[2] * r1.z,
+      y: R[3] * r1.x + R[4] * r1.y + R[5] * r1.z,
+      z: R[6] * r1.x + R[7] * r1.y + R[8] * r1.z
+    };
+    return n;
+  }
+
+  hull(t) {
+    let p = this.points,
+        _p = [],
+        q = [],
+        idx = 0;
+    q[idx++] = p[0];
+    q[idx++] = p[1];
+    q[idx++] = p[2];
+
+    if (this.order === 3) {
+      q[idx++] = p[3];
+    } // we lerp between all points at each iteration, until we have 1 point left.
+
+
+    while (p.length > 1) {
+      _p = [];
+
+      for (let i = 0, pt, l = p.length - 1; i < l; i++) {
+        pt = _utils.utils.lerp(t, p[i], p[i + 1]);
+        q[idx++] = pt;
+
+        _p.push(pt);
+      }
+
+      p = _p;
+    }
+
+    return q;
+  }
+
+  split(t1, t2) {
+    // shortcuts
+    if (t1 === 0 && !!t2) {
+      return this.split(t2).left;
+    }
+
+    if (t2 === 1) {
+      return this.split(t1).right;
+    } // no shortcut: use "de Casteljau" iteration.
+
+
+    const q = this.hull(t1);
+    const result = {
+      left: this.order === 2 ? new Bezier([q[0], q[3], q[5]]) : new Bezier([q[0], q[4], q[7], q[9]]),
+      right: this.order === 2 ? new Bezier([q[5], q[4], q[2]]) : new Bezier([q[9], q[8], q[6], q[3]]),
+      span: q
+    }; // make sure we bind _t1/_t2 information!
+
+    result.left._t1 = _utils.utils.map(0, 0, 1, this._t1, this._t2);
+    result.left._t2 = _utils.utils.map(t1, 0, 1, this._t1, this._t2);
+    result.right._t1 = _utils.utils.map(t1, 0, 1, this._t1, this._t2);
+    result.right._t2 = _utils.utils.map(1, 0, 1, this._t1, this._t2); // if we have no t2, we're done
+
+    if (!t2) {
+      return result;
+    } // if we have a t2, split again:
+
+
+    t2 = _utils.utils.map(t2, t1, 1, 0, 1);
+    return result.right.split(t2).left;
+  }
+
+  extrema() {
+    const result = {};
+    let roots = [];
+    this.dims.forEach(function (dim) {
+      let mfn = function (v) {
+        return v[dim];
+      };
+
+      let p = this.dpoints[0].map(mfn);
+      result[dim] = _utils.utils.droots(p);
+
+      if (this.order === 3) {
+        p = this.dpoints[1].map(mfn);
+        result[dim] = result[dim].concat(_utils.utils.droots(p));
+      }
+
+      result[dim] = result[dim].filter(function (t) {
+        return t >= 0 && t <= 1;
+      });
+      roots = roots.concat(result[dim].sort(_utils.utils.numberSort));
+    }.bind(this));
+    result.values = roots.sort(_utils.utils.numberSort).filter(function (v, idx) {
+      return roots.indexOf(v) === idx;
+    });
+    return result;
+  }
+
+  bbox() {
+    const extrema = this.extrema(),
+          result = {};
+    this.dims.forEach(function (d) {
+      result[d] = _utils.utils.getminmax(this, d, extrema[d]);
+    }.bind(this));
+    return result;
+  }
+
+  overlaps(curve) {
+    const lbbox = this.bbox(),
+          tbbox = curve.bbox();
+    return _utils.utils.bboxoverlap(lbbox, tbbox);
+  }
+
+  offset(t, d) {
+    if (typeof d !== "undefined") {
+      const c = this.get(t),
+            n = this.normal(t);
+      const ret = {
+        c: c,
+        n: n,
+        x: c.x + n.x * d,
+        y: c.y + n.y * d
+      };
+
+      if (this._3d) {
+        ret.z = c.z + n.z * d;
+      }
+
+      return ret;
+    }
+
+    if (this._linear) {
+      const nv = this.normal(0),
+            coords = this.points.map(function (p) {
+        const ret = {
+          x: p.x + t * nv.x,
+          y: p.y + t * nv.y
+        };
+
+        if (p.z && nv.z) {
+          ret.z = p.z + t * nv.z;
+        }
+
+        return ret;
+      });
+      return [new Bezier(coords)];
+    }
+
+    return this.reduce().map(function (s) {
+      if (s._linear) {
+        return s.offset(t)[0];
+      }
+
+      return s.scale(t);
+    });
+  }
+
+  simple() {
+    if (this.order === 3) {
+      const a1 = _utils.utils.angle(this.points[0], this.points[3], this.points[1]);
+
+      const a2 = _utils.utils.angle(this.points[0], this.points[3], this.points[2]);
+
+      if (a1 > 0 && a2 < 0 || a1 < 0 && a2 > 0) return false;
+    }
+
+    const n1 = this.normal(0);
+    const n2 = this.normal(1);
+    let s = n1.x * n2.x + n1.y * n2.y;
+
+    if (this._3d) {
+      s += n1.z * n2.z;
+    }
+
+    return abs(acos(s)) < pi / 3;
+  }
+
+  reduce() {
+    // TODO: examine these var types in more detail...
+    let i,
+        t1 = 0,
+        t2 = 0,
+        step = 0.01,
+        segment,
+        pass1 = [],
+        pass2 = []; // first pass: split on extrema
+
+    let extrema = this.extrema().values;
+
+    if (extrema.indexOf(0) === -1) {
+      extrema = [0].concat(extrema);
+    }
+
+    if (extrema.indexOf(1) === -1) {
+      extrema.push(1);
+    }
+
+    for (t1 = extrema[0], i = 1; i < extrema.length; i++) {
+      t2 = extrema[i];
+      segment = this.split(t1, t2);
+      segment._t1 = t1;
+      segment._t2 = t2;
+      pass1.push(segment);
+      t1 = t2;
+    } // second pass: further reduce these segments to simple segments
+
+
+    pass1.forEach(function (p1) {
+      t1 = 0;
+      t2 = 0;
+
+      while (t2 <= 1) {
+        for (t2 = t1 + step; t2 <= 1 + step; t2 += step) {
+          segment = p1.split(t1, t2);
+
+          if (!segment.simple()) {
+            t2 -= step;
+
+            if (abs(t1 - t2) < step) {
+              // we can never form a reduction
+              return [];
+            }
+
+            segment = p1.split(t1, t2);
+            segment._t1 = _utils.utils.map(t1, 0, 1, p1._t1, p1._t2);
+            segment._t2 = _utils.utils.map(t2, 0, 1, p1._t1, p1._t2);
+            pass2.push(segment);
+            t1 = t2;
+            break;
+          }
+        }
+      }
+
+      if (t1 < 1) {
+        segment = p1.split(t1, 1);
+        segment._t1 = _utils.utils.map(t1, 0, 1, p1._t1, p1._t2);
+        segment._t2 = p1._t2;
+        pass2.push(segment);
+      }
+    });
+    return pass2;
+  }
+
+  scale(d) {
+    const order = this.order;
+    let distanceFn = false;
+
+    if (typeof d === "function") {
+      distanceFn = d;
+    }
+
+    if (distanceFn && order === 2) {
+      return this.raise().scale(distanceFn);
+    } // TODO: add special handling for degenerate (=linear) curves.
+
+
+    const clockwise = this.clockwise;
+    const r1 = distanceFn ? distanceFn(0) : d;
+    const r2 = distanceFn ? distanceFn(1) : d;
+    const v = [this.offset(0, 10), this.offset(1, 10)];
+    const points = this.points;
+    const np = [];
+
+    const o = _utils.utils.lli4(v[0], v[0].c, v[1], v[1].c);
+
+    if (!o) {
+      throw new Error("cannot scale this curve. Try reducing it first.");
+    } // move all points by distance 'd' wrt the origin 'o'
+    // move end points by fixed distance along normal.
+
+
+    [0, 1].forEach(function (t) {
+      const p = np[t * order] = _utils.utils.copy(points[t * order]);
+
+      p.x += (t ? r2 : r1) * v[t].n.x;
+      p.y += (t ? r2 : r1) * v[t].n.y;
+    });
+
+    if (!distanceFn) {
+      // move control points to lie on the intersection of the offset
+      // derivative vector, and the origin-through-control vector
+      [0, 1].forEach(t => {
+        if (order === 2 && !!t) return;
+        const p = np[t * order];
+        const d = this.derivative(t);
+        const p2 = {
+          x: p.x + d.x,
+          y: p.y + d.y
+        };
+        np[t + 1] = _utils.utils.lli4(p, p2, o, points[t + 1]);
+      });
+      return new Bezier(np);
+    } // move control points by "however much necessary to
+    // ensure the correct tangent to endpoint".
+
+
+    [0, 1].forEach(function (t) {
+      if (order === 2 && !!t) return;
+      var p = points[t + 1];
+      var ov = {
+        x: p.x - o.x,
+        y: p.y - o.y
+      };
+      var rc = distanceFn ? distanceFn((t + 1) / order) : d;
+      if (distanceFn && !clockwise) rc = -rc;
+      var m = sqrt(ov.x * ov.x + ov.y * ov.y);
+      ov.x /= m;
+      ov.y /= m;
+      np[t + 1] = {
+        x: p.x + rc * ov.x,
+        y: p.y + rc * ov.y
+      };
+    });
+    return new Bezier(np);
+  }
+
+  outline(d1, d2, d3, d4) {
+    d2 = typeof d2 === "undefined" ? d1 : d2;
+    const reduced = this.reduce(),
+          len = reduced.length,
+          fcurves = [];
+    let bcurves = [],
+        p,
+        alen = 0,
+        tlen = this.length();
+    const graduated = typeof d3 !== "undefined" && typeof d4 !== "undefined";
+
+    function linearDistanceFunction(s, e, tlen, alen, slen) {
+      return function (v) {
+        const f1 = alen / tlen,
+              f2 = (alen + slen) / tlen,
+              d = e - s;
+        return _utils.utils.map(v, 0, 1, s + f1 * d, s + f2 * d);
+      };
+    } // form curve oulines
+
+
+    reduced.forEach(function (segment) {
+      const slen = segment.length();
+
+      if (graduated) {
+        fcurves.push(segment.scale(linearDistanceFunction(d1, d3, tlen, alen, slen)));
+        bcurves.push(segment.scale(linearDistanceFunction(-d2, -d4, tlen, alen, slen)));
+      } else {
+        fcurves.push(segment.scale(d1));
+        bcurves.push(segment.scale(-d2));
+      }
+
+      alen += slen;
+    }); // reverse the "return" outline
+
+    bcurves = bcurves.map(function (s) {
+      p = s.points;
+
+      if (p[3]) {
+        s.points = [p[3], p[2], p[1], p[0]];
+      } else {
+        s.points = [p[2], p[1], p[0]];
+      }
+
+      return s;
+    }).reverse(); // form the endcaps as lines
+
+    const fs = fcurves[0].points[0],
+          fe = fcurves[len - 1].points[fcurves[len - 1].points.length - 1],
+          bs = bcurves[len - 1].points[bcurves[len - 1].points.length - 1],
+          be = bcurves[0].points[0],
+          ls = _utils.utils.makeline(bs, fs),
+          le = _utils.utils.makeline(fe, be),
+          segments = [ls].concat(fcurves).concat([le]).concat(bcurves),
+          slen = segments.length;
+
+    return new _polyBezier.PolyBezier(segments);
+  }
+
+  outlineshapes(d1, d2, curveIntersectionThreshold) {
+    d2 = d2 || d1;
+    const outline = this.outline(d1, d2).curves;
+    const shapes = [];
+
+    for (let i = 1, len = outline.length; i < len / 2; i++) {
+      const shape = _utils.utils.makeshape(outline[i], outline[len - i], curveIntersectionThreshold);
+
+      shape.startcap.virtual = i > 1;
+      shape.endcap.virtual = i < len / 2 - 1;
+      shapes.push(shape);
+    }
+
+    return shapes;
+  }
+
+  intersects(curve, curveIntersectionThreshold) {
+    if (!curve) return this.selfintersects(curveIntersectionThreshold);
+
+    if (curve.p1 && curve.p2) {
+      return this.lineIntersects(curve);
+    }
+
+    if (curve instanceof Bezier) {
+      curve = curve.reduce();
+    }
+
+    return this.curveintersects(this.reduce(), curve, curveIntersectionThreshold);
+  }
+
+  lineIntersects(line) {
+    const mx = min(line.p1.x, line.p2.x),
+          my = min(line.p1.y, line.p2.y),
+          MX = max(line.p1.x, line.p2.x),
+          MY = max(line.p1.y, line.p2.y);
+    return _utils.utils.roots(this.points, line).filter(t => {
+      var p = this.get(t);
+      return _utils.utils.between(p.x, mx, MX) && _utils.utils.between(p.y, my, MY);
+    });
+  }
+
+  selfintersects(curveIntersectionThreshold) {
+    // "simple" curves cannot intersect with their direct
+    // neighbour, so for each segment X we check whether
+    // it intersects [0:x-2][x+2:last].
+    const reduced = this.reduce(),
+          len = reduced.length - 2,
+          results = [];
+
+    for (let i = 0, result, left, right; i < len; i++) {
+      left = reduced.slice(i, i + 1);
+      right = reduced.slice(i + 2);
+      result = this.curveintersects(left, right, curveIntersectionThreshold);
+      results.push(...result);
+    }
+
+    return results;
+  }
+
+  curveintersects(c1, c2, curveIntersectionThreshold) {
+    const pairs = []; // step 1: pair off any overlapping segments
+
+    c1.forEach(function (l) {
+      c2.forEach(function (r) {
+        if (l.overlaps(r)) {
+          pairs.push({
+            left: l,
+            right: r
+          });
+        }
+      });
+    }); // step 2: for each pairing, run through the convergence algorithm.
+
+    let intersections = [];
+    pairs.forEach(function (pair) {
+      const result = _utils.utils.pairiteration(pair.left, pair.right, curveIntersectionThreshold);
+
+      if (result.length > 0) {
+        intersections = intersections.concat(result);
+      }
+    });
+    return intersections;
+  }
+
+  arcs(errorThreshold) {
+    errorThreshold = errorThreshold || 0.5;
+    return this._iterate(errorThreshold, []);
+  }
+
+  _error(pc, np1, s, e) {
+    const q = (e - s) / 4,
+          c1 = this.get(s + q),
+          c2 = this.get(e - q),
+          ref = _utils.utils.dist(pc, np1),
+          d1 = _utils.utils.dist(pc, c1),
+          d2 = _utils.utils.dist(pc, c2);
+
+    return abs(d1 - ref) + abs(d2 - ref);
+  }
+
+  _iterate(errorThreshold, circles) {
+    let t_s = 0,
+        t_e = 1,
+        safety; // we do a binary search to find the "good `t` closest to no-longer-good"
+
+    do {
+      safety = 0; // step 1: start with the maximum possible arc
+
+      t_e = 1; // points:
+
+      let np1 = this.get(t_s),
+          np2,
+          np3,
+          arc,
+          prev_arc; // booleans:
+
+      let curr_good = false,
+          prev_good = false,
+          done; // numbers:
+
+      let t_m = t_e,
+          prev_e = 1,
+          step = 0; // step 2: find the best possible arc
+
+      do {
+        prev_good = curr_good;
+        prev_arc = arc;
+        t_m = (t_s + t_e) / 2;
+        step++;
+        np2 = this.get(t_m);
+        np3 = this.get(t_e);
+        arc = _utils.utils.getccenter(np1, np2, np3); //also save the t values
+
+        arc.interval = {
+          start: t_s,
+          end: t_e
+        };
+
+        let error = this._error(arc, np1, t_s, t_e);
+
+        curr_good = error <= errorThreshold;
+        done = prev_good && !curr_good;
+        if (!done) prev_e = t_e; // this arc is fine: we can move 'e' up to see if we can find a wider arc
+
+        if (curr_good) {
+          // if e is already at max, then we're done for this arc.
+          if (t_e >= 1) {
+            // make sure we cap at t=1
+            arc.interval.end = prev_e = 1;
+            prev_arc = arc; // if we capped the arc segment to t=1 we also need to make sure that
+            // the arc's end angle is correct with respect to the bezier end point.
+
+            if (t_e > 1) {
+              let d = {
+                x: arc.x + arc.r * cos(arc.e),
+                y: arc.y + arc.r * sin(arc.e)
+              };
+              arc.e += _utils.utils.angle({
+                x: arc.x,
+                y: arc.y
+              }, d, this.get(1));
+            }
+
+            break;
+          } // if not, move it up by half the iteration distance
+
+
+          t_e = t_e + (t_e - t_s) / 2;
+        } else {
+          // this is a bad arc: we need to move 'e' down to find a good arc
+          t_e = t_m;
+        }
+      } while (!done && safety++ < 100);
+
+      if (safety >= 100) {
+        break;
+      } // console.log("L835: [F] arc found", t_s, prev_e, prev_arc.x, prev_arc.y, prev_arc.s, prev_arc.e);
+
+
+      prev_arc = prev_arc ? prev_arc : arc;
+      circles.push(prev_arc);
+      t_s = prev_e;
+    } while (t_e < 1);
+
+    return circles;
+  }
+
+}
+
+exports.Bezier = Bezier;

--- a/dist/cjs/normalise-svg.js
+++ b/dist/cjs/normalise-svg.js
@@ -1,0 +1,229 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = normalizePath;
+
+/**
+ * Normalise an SVG path to absolute coordinates
+ * and full commands, rather than relative coordinates
+ * and/or shortcut commands.
+ */
+function normalizePath(d) {
+  // preprocess "d" so that we have spaces between values
+  d = d.replace(/,/g, " ") // replace commas with spaces
+  .replace(/-/g, " - ") // add spacing around minus signs
+  .replace(/-\s+/g, "-") // remove spacing to the right of minus signs.
+  .replace(/([a-zA-Z])/g, " $1 "); // set up the variables used in this function
+
+  const instructions = d.replace(/([a-zA-Z])\s?/g, "|$1").split("|"),
+        instructionLength = instructions.length;
+  let i,
+      instruction,
+      op,
+      lop,
+      args = [],
+      alen,
+      a,
+      sx = 0,
+      sy = 0,
+      x = 0,
+      y = 0,
+      cx = 0,
+      cy = 0,
+      cx2 = 0,
+      cy2 = 0,
+      rx = 0,
+      ry = 0,
+      xrot = 0,
+      lflag = 0,
+      sweep = 0,
+      normalized = ""; // we run through the instruction list starting at 1, not 0,
+  // because we split up "|M x y ...." so the first element will
+  // always be an empty string. By design.
+
+  for (i = 1; i < instructionLength; i++) {
+    // which instruction is this?
+    instruction = instructions[i];
+    op = instruction.substring(0, 1);
+    lop = op.toLowerCase(); // what are the arguments? note that we need to convert
+    // all strings into numbers, or + will do silly things.
+
+    args = instruction.replace(op, "").trim().split(" ");
+    args = args.filter(function (v) {
+      return v !== "";
+    }).map(parseFloat);
+    alen = args.length; // we could use a switch, but elaborate code in a "case" with
+    // fallthrough is just horrid to read. So let's use ifthen
+    // statements instead.
+    // moveto command (plus possible lineto)
+
+    if (lop === "m") {
+      normalized += "M ";
+
+      if (op === "m") {
+        x += args[0];
+        y += args[1];
+      } else {
+        x = args[0];
+        y = args[1];
+      } // records start position, for dealing
+      // with the shape close operator ('Z')
+
+
+      sx = x;
+      sy = y;
+      normalized += x + " " + y + " ";
+
+      if (alen > 2) {
+        for (a = 0; a < alen; a += 2) {
+          if (op === "m") {
+            x += args[a];
+            y += args[a + 1];
+          } else {
+            x = args[a];
+            y = args[a + 1];
+          }
+
+          normalized += "L " + x + " " + y + " ";
+        }
+      }
+    } // lineto commands
+    else if (lop === "l") {
+        for (a = 0; a < alen; a += 2) {
+          if (op === "l") {
+            x += args[a];
+            y += args[a + 1];
+          } else {
+            x = args[a];
+            y = args[a + 1];
+          }
+
+          normalized += "L " + x + " " + y + " ";
+        }
+      } else if (lop === "h") {
+        for (a = 0; a < alen; a++) {
+          if (op === "h") {
+            x += args[a];
+          } else {
+            x = args[a];
+          }
+
+          normalized += "L " + x + " " + y + " ";
+        }
+      } else if (lop === "v") {
+        for (a = 0; a < alen; a++) {
+          if (op === "v") {
+            y += args[a];
+          } else {
+            y = args[a];
+          }
+
+          normalized += "L " + x + " " + y + " ";
+        }
+      } // quadratic curveto commands
+      else if (lop === "q") {
+          for (a = 0; a < alen; a += 4) {
+            if (op === "q") {
+              cx = x + args[a];
+              cy = y + args[a + 1];
+              x += args[a + 2];
+              y += args[a + 3];
+            } else {
+              cx = args[a];
+              cy = args[a + 1];
+              x = args[a + 2];
+              y = args[a + 3];
+            }
+
+            normalized += "Q " + cx + " " + cy + " " + x + " " + y + " ";
+          }
+        } else if (lop === "t") {
+          for (a = 0; a < alen; a += 2) {
+            // reflect previous cx/cy over x/y
+            cx = x + (x - cx);
+            cy = y + (y - cy); // then get real end point
+
+            if (op === "t") {
+              x += args[a];
+              y += args[a + 1];
+            } else {
+              x = args[a];
+              y = args[a + 1];
+            }
+
+            normalized += "Q " + cx + " " + cy + " " + x + " " + y + " ";
+          }
+        } // cubic curveto commands
+        else if (lop === "c") {
+            for (a = 0; a < alen; a += 6) {
+              if (op === "c") {
+                cx = x + args[a];
+                cy = y + args[a + 1];
+                cx2 = x + args[a + 2];
+                cy2 = y + args[a + 3];
+                x += args[a + 4];
+                y += args[a + 5];
+              } else {
+                cx = args[a];
+                cy = args[a + 1];
+                cx2 = args[a + 2];
+                cy2 = args[a + 3];
+                x = args[a + 4];
+                y = args[a + 5];
+              }
+
+              normalized += "C " + cx + " " + cy + " " + cx2 + " " + cy2 + " " + x + " " + y + " ";
+            }
+          } else if (lop === "s") {
+            for (a = 0; a < alen; a += 4) {
+              // reflect previous cx2/cy2 over x/y
+              cx = x + (x - cx2);
+              cy = y + (y - cy2); // then get real control and end point
+
+              if (op === "s") {
+                cx2 = x + args[a];
+                cy2 = y + args[a + 1];
+                x += args[a + 2];
+                y += args[a + 3];
+              } else {
+                cx2 = args[a];
+                cy2 = args[a + 1];
+                x = args[a + 2];
+                y = args[a + 3];
+              }
+
+              normalized += "C " + cx + " " + cy + " " + cx2 + " " + cy2 + " " + x + " " + y + " ";
+            }
+          } //   rx ry x-axis-rotation large-arc-flag sweep-flag  x   y
+          // a 25,25             -30              0,         1 50,-25
+          // arc command
+          else if (lop === "a") {
+              for (a = 0; a < alen; a += 7) {
+                rx = args[a];
+                ry = args[a + 1];
+                xrot = args[a + 2];
+                lflag = args[a + 3];
+                sweep = args[a + 4];
+
+                if (op === "a") {
+                  x += args[a + 5];
+                  y += args[a + 6];
+                } else {
+                  x = args[a + 5];
+                  y = args[a + 6];
+                }
+
+                normalized += "A " + rx + " " + ry + " " + xrot + " " + lflag + " " + sweep + " " + x + " " + y + " ";
+              }
+            } else if (lop === "z") {
+              normalized += "Z "; // not unimportant: path closing changes the current x/y coordinate
+
+              x = sx;
+              y = sy;
+            }
+  }
+
+  return normalized.trim();
+}

--- a/dist/cjs/poly-bezier.js
+++ b/dist/cjs/poly-bezier.js
@@ -1,0 +1,73 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.PolyBezier = void 0;
+
+var _utils = require("./utils.js");
+
+/**
+ * Poly Bezier
+ * @param {[type]} curves [description]
+ */
+class PolyBezier {
+  constructor(curves) {
+    this.curves = [];
+    this._3d = false;
+
+    if (!!curves) {
+      this.curves = curves;
+      this._3d = this.curves[0]._3d;
+    }
+  }
+
+  valueOf() {
+    return this.toString();
+  }
+
+  toString() {
+    return "[" + this.curves.map(function (curve) {
+      return _utils.utils.pointsToString(curve.points);
+    }).join(", ") + "]";
+  }
+
+  addCurve(curve) {
+    this.curves.push(curve);
+    this._3d = this._3d || curve._3d;
+  }
+
+  length() {
+    return this.curves.map(function (v) {
+      return v.length();
+    }).reduce(function (a, b) {
+      return a + b;
+    });
+  }
+
+  curve(idx) {
+    return this.curves[idx];
+  }
+
+  bbox() {
+    const c = this.curves;
+    var bbox = c[0].bbox();
+
+    for (var i = 1; i < c.length; i++) {
+      _utils.utils.expandbox(bbox, c[i].bbox());
+    }
+
+    return bbox;
+  }
+
+  offset(d) {
+    const offset = [];
+    this.curves.forEach(function (v) {
+      offset.push(...v.offset(d));
+    });
+    return new PolyBezier(offset);
+  }
+
+}
+
+exports.PolyBezier = PolyBezier;

--- a/dist/cjs/svg-to-beziers.js
+++ b/dist/cjs/svg-to-beziers.js
@@ -1,0 +1,69 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.convertPath = convertPath;
+
+var _normaliseSvg = _interopRequireDefault(require("./normalise-svg.js"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+let M = {
+  x: false,
+  y: false
+};
+/**
+ * ...
+ */
+
+function makeBezier(Bezier, term, values) {
+  if (term === "Z") return;
+
+  if (term === "M") {
+    M = {
+      x: values[0],
+      y: values[1]
+    };
+    return;
+  }
+
+  const curve = new Bezier(M.x, M.y, ...values);
+  const last = values.slice(-2);
+  M = {
+    x: last[0],
+    y: last[1]
+  };
+  return curve;
+}
+/**
+ * ...
+ */
+
+
+function convertPath(Bezier, d) {
+  const terms = (0, _normaliseSvg.default)(d).split(" "),
+        matcher = new RegExp("[MLCQZ]", "");
+  let term,
+      segment,
+      values,
+      segments = [],
+      ARGS = {
+    C: 6,
+    Q: 4,
+    L: 2,
+    M: 2
+  };
+
+  while (terms.length) {
+    term = terms.splice(0, 1)[0];
+
+    if (matcher.test(term)) {
+      values = terms.splice(0, ARGS[term]).map(parseFloat);
+      segment = makeBezier(Bezier, term, values);
+      if (segment) segments.push(segment);
+    }
+  }
+
+  return new Bezier.PolyBezier(segments);
+}

--- a/dist/cjs/utils.js
+++ b/dist/cjs/utils.js
@@ -1,0 +1,892 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.utils = void 0;
+
+var _bezier = require("./bezier.js");
+
+// math-inlining.
+const {
+  abs,
+  cos,
+  sin,
+  acos,
+  atan2,
+  sqrt,
+  pow
+} = Math; // cube root function yielding real roots
+
+function crt(v) {
+  return v < 0 ? -pow(-v, 1 / 3) : pow(v, 1 / 3);
+} // trig constants
+
+
+const pi = Math.PI,
+      tau = 2 * pi,
+      quart = pi / 2,
+      // float precision significant decimal
+epsilon = 0.000001,
+      // extremas used in bbox calculation and similar algorithms
+nMax = Number.MAX_SAFE_INTEGER || 9007199254740991,
+      nMin = Number.MIN_SAFE_INTEGER || -9007199254740991,
+      // a zero coordinate, which is surprisingly useful
+ZERO = {
+  x: 0,
+  y: 0,
+  z: 0
+}; // Bezier utility functions
+
+const utils = {
+  // Legendre-Gauss abscissae with n=24 (x_i values, defined at i=n as the roots of the nth order Legendre polynomial Pn(x))
+  Tvalues: [-0.0640568928626056260850430826247450385909, 0.0640568928626056260850430826247450385909, -0.1911188674736163091586398207570696318404, 0.1911188674736163091586398207570696318404, -0.3150426796961633743867932913198102407864, 0.3150426796961633743867932913198102407864, -0.4337935076260451384870842319133497124524, 0.4337935076260451384870842319133497124524, -0.5454214713888395356583756172183723700107, 0.5454214713888395356583756172183723700107, -0.6480936519369755692524957869107476266696, 0.6480936519369755692524957869107476266696, -0.7401241915785543642438281030999784255232, 0.7401241915785543642438281030999784255232, -0.8200019859739029219539498726697452080761, 0.8200019859739029219539498726697452080761, -0.8864155270044010342131543419821967550873, 0.8864155270044010342131543419821967550873, -0.9382745520027327585236490017087214496548, 0.9382745520027327585236490017087214496548, -0.9747285559713094981983919930081690617411, 0.9747285559713094981983919930081690617411, -0.9951872199970213601799974097007368118745, 0.9951872199970213601799974097007368118745],
+  // Legendre-Gauss weights with n=24 (w_i values, defined by a function linked to in the Bezier primer article)
+  Cvalues: [0.1279381953467521569740561652246953718517, 0.1279381953467521569740561652246953718517, 0.1258374563468282961213753825111836887264, 0.1258374563468282961213753825111836887264, 0.121670472927803391204463153476262425607, 0.121670472927803391204463153476262425607, 0.1155056680537256013533444839067835598622, 0.1155056680537256013533444839067835598622, 0.1074442701159656347825773424466062227946, 0.1074442701159656347825773424466062227946, 0.0976186521041138882698806644642471544279, 0.0976186521041138882698806644642471544279, 0.086190161531953275917185202983742667185, 0.086190161531953275917185202983742667185, 0.0733464814110803057340336152531165181193, 0.0733464814110803057340336152531165181193, 0.0592985849154367807463677585001085845412, 0.0592985849154367807463677585001085845412, 0.0442774388174198061686027482113382288593, 0.0442774388174198061686027482113382288593, 0.0285313886289336631813078159518782864491, 0.0285313886289336631813078159518782864491, 0.0123412297999871995468056670700372915759, 0.0123412297999871995468056670700372915759],
+  arcfn: function (t, derivativeFn) {
+    const d = derivativeFn(t);
+    let l = d.x * d.x + d.y * d.y;
+
+    if (typeof d.z !== "undefined") {
+      l += d.z * d.z;
+    }
+
+    return sqrt(l);
+  },
+  compute: function (t, points, _3d) {
+    // shortcuts
+    if (t === 0) {
+      points[0].t = 0;
+      return points[0];
+    }
+
+    const order = points.length - 1;
+
+    if (t === 1) {
+      points[order].t = 1;
+      return points[order];
+    }
+
+    const mt = 1 - t;
+    let p = points; // constant?
+
+    if (order === 0) {
+      points[0].t = t;
+      return points[0];
+    } // linear?
+
+
+    if (order === 1) {
+      const ret = {
+        x: mt * p[0].x + t * p[1].x,
+        y: mt * p[0].y + t * p[1].y,
+        t: t
+      };
+
+      if (_3d) {
+        ret.z = mt * p[0].z + t * p[1].z;
+      }
+
+      return ret;
+    } // quadratic/cubic curve?
+
+
+    if (order < 4) {
+      let mt2 = mt * mt,
+          t2 = t * t,
+          a,
+          b,
+          c,
+          d = 0;
+
+      if (order === 2) {
+        p = [p[0], p[1], p[2], ZERO];
+        a = mt2;
+        b = mt * t * 2;
+        c = t2;
+      } else if (order === 3) {
+        a = mt2 * mt;
+        b = mt2 * t * 3;
+        c = mt * t2 * 3;
+        d = t * t2;
+      }
+
+      const ret = {
+        x: a * p[0].x + b * p[1].x + c * p[2].x + d * p[3].x,
+        y: a * p[0].y + b * p[1].y + c * p[2].y + d * p[3].y,
+        t: t
+      };
+
+      if (_3d) {
+        ret.z = a * p[0].z + b * p[1].z + c * p[2].z + d * p[3].z;
+      }
+
+      return ret;
+    } // higher order curves: use de Casteljau's computation
+
+
+    const dCpts = JSON.parse(JSON.stringify(points));
+
+    while (dCpts.length > 1) {
+      for (let i = 0; i < dCpts.length - 1; i++) {
+        dCpts[i] = {
+          x: dCpts[i].x + (dCpts[i + 1].x - dCpts[i].x) * t,
+          y: dCpts[i].y + (dCpts[i + 1].y - dCpts[i].y) * t
+        };
+
+        if (typeof dCpts[i].z !== "undefined") {
+          dCpts[i] = dCpts[i].z + (dCpts[i + 1].z - dCpts[i].z) * t;
+        }
+      }
+
+      dCpts.splice(dCpts.length - 1, 1);
+    }
+
+    dCpts[0].t = t;
+    return dCpts[0];
+  },
+  computeWithRatios: function (t, points, ratios, _3d) {
+    const mt = 1 - t,
+          r = ratios,
+          p = points;
+    let f1 = r[0],
+        f2 = r[1],
+        f3 = r[2],
+        f4 = r[3],
+        d; // spec for linear
+
+    f1 *= mt;
+    f2 *= t;
+
+    if (p.length === 2) {
+      d = f1 + f2;
+      return {
+        x: (f1 * p[0].x + f2 * p[1].x) / d,
+        y: (f1 * p[0].y + f2 * p[1].y) / d,
+        z: !_3d ? false : (f1 * p[0].z + f2 * p[1].z) / d,
+        t: t
+      };
+    } // upgrade to quadratic
+
+
+    f1 *= mt;
+    f2 *= 2 * mt;
+    f3 *= t * t;
+
+    if (p.length === 3) {
+      d = f1 + f2 + f3;
+      return {
+        x: (f1 * p[0].x + f2 * p[1].x + f3 * p[2].x) / d,
+        y: (f1 * p[0].y + f2 * p[1].y + f3 * p[2].y) / d,
+        z: !_3d ? false : (f1 * p[0].z + f2 * p[1].z + f3 * p[2].z) / d,
+        t: t
+      };
+    } // upgrade to cubic
+
+
+    f1 *= mt;
+    f2 *= 1.5 * mt;
+    f3 *= 3 * mt;
+    f4 *= t * t * t;
+
+    if (p.length === 4) {
+      d = f1 + f2 + f3 + f4;
+      return {
+        x: (f1 * p[0].x + f2 * p[1].x + f3 * p[2].x + f4 * p[3].x) / d,
+        y: (f1 * p[0].y + f2 * p[1].y + f3 * p[2].y + f4 * p[3].y) / d,
+        z: !_3d ? false : (f1 * p[0].z + f2 * p[1].z + f3 * p[2].z + f4 * p[3].z) / d,
+        t: t
+      };
+    }
+  },
+  derive: function (points, _3d) {
+    const dpoints = [];
+
+    for (let p = points, d = p.length, c = d - 1; d > 1; d--, c--) {
+      const list = [];
+
+      for (let j = 0, dpt; j < c; j++) {
+        dpt = {
+          x: c * (p[j + 1].x - p[j].x),
+          y: c * (p[j + 1].y - p[j].y)
+        };
+
+        if (_3d) {
+          dpt.z = c * (p[j + 1].z - p[j].z);
+        }
+
+        list.push(dpt);
+      }
+
+      dpoints.push(list);
+      p = list;
+    }
+
+    return dpoints;
+  },
+  between: function (v, m, M) {
+    return m <= v && v <= M || utils.approximately(v, m) || utils.approximately(v, M);
+  },
+  approximately: function (a, b, precision) {
+    return abs(a - b) <= (precision || epsilon);
+  },
+  length: function (derivativeFn) {
+    const z = 0.5,
+          len = utils.Tvalues.length;
+    let sum = 0;
+
+    for (let i = 0, t; i < len; i++) {
+      t = z * utils.Tvalues[i] + z;
+      sum += utils.Cvalues[i] * utils.arcfn(t, derivativeFn);
+    }
+
+    return z * sum;
+  },
+  map: function (v, ds, de, ts, te) {
+    const d1 = de - ds,
+          d2 = te - ts,
+          v2 = v - ds,
+          r = v2 / d1;
+    return ts + d2 * r;
+  },
+  lerp: function (r, v1, v2) {
+    const ret = {
+      x: v1.x + r * (v2.x - v1.x),
+      y: v1.y + r * (v2.y - v1.y)
+    };
+
+    if (!!v1.z && !!v2.z) {
+      ret.z = v1.z + r * (v2.z - v1.z);
+    }
+
+    return ret;
+  },
+  pointToString: function (p) {
+    let s = p.x + "/" + p.y;
+
+    if (typeof p.z !== "undefined") {
+      s += "/" + p.z;
+    }
+
+    return s;
+  },
+  pointsToString: function (points) {
+    return "[" + points.map(utils.pointToString).join(", ") + "]";
+  },
+  copy: function (obj) {
+    return JSON.parse(JSON.stringify(obj));
+  },
+  angle: function (o, v1, v2) {
+    const dx1 = v1.x - o.x,
+          dy1 = v1.y - o.y,
+          dx2 = v2.x - o.x,
+          dy2 = v2.y - o.y,
+          cross = dx1 * dy2 - dy1 * dx2,
+          dot = dx1 * dx2 + dy1 * dy2;
+    return atan2(cross, dot);
+  },
+  // round as string, to avoid rounding errors
+  round: function (v, d) {
+    const s = "" + v;
+    const pos = s.indexOf(".");
+    return parseFloat(s.substring(0, pos + 1 + d));
+  },
+  dist: function (p1, p2) {
+    const dx = p1.x - p2.x,
+          dy = p1.y - p2.y;
+    return sqrt(dx * dx + dy * dy);
+  },
+  closest: function (LUT, point) {
+    let mdist = pow(2, 63),
+        mpos,
+        d;
+    LUT.forEach(function (p, idx) {
+      d = utils.dist(point, p);
+
+      if (d < mdist) {
+        mdist = d;
+        mpos = idx;
+      }
+    });
+    return {
+      mdist: mdist,
+      mpos: mpos
+    };
+  },
+  abcratio: function (t, n) {
+    // see ratio(t) note on http://pomax.github.io/bezierinfo/#abc
+    if (n !== 2 && n !== 3) {
+      return false;
+    }
+
+    if (typeof t === "undefined") {
+      t = 0.5;
+    } else if (t === 0 || t === 1) {
+      return t;
+    }
+
+    const bottom = pow(t, n) + pow(1 - t, n),
+          top = bottom - 1;
+    return abs(top / bottom);
+  },
+  projectionratio: function (t, n) {
+    // see u(t) note on http://pomax.github.io/bezierinfo/#abc
+    if (n !== 2 && n !== 3) {
+      return false;
+    }
+
+    if (typeof t === "undefined") {
+      t = 0.5;
+    } else if (t === 0 || t === 1) {
+      return t;
+    }
+
+    const top = pow(1 - t, n),
+          bottom = pow(t, n) + top;
+    return top / bottom;
+  },
+  lli8: function (x1, y1, x2, y2, x3, y3, x4, y4) {
+    const nx = (x1 * y2 - y1 * x2) * (x3 - x4) - (x1 - x2) * (x3 * y4 - y3 * x4),
+          ny = (x1 * y2 - y1 * x2) * (y3 - y4) - (y1 - y2) * (x3 * y4 - y3 * x4),
+          d = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4);
+
+    if (d == 0) {
+      return false;
+    }
+
+    return {
+      x: nx / d,
+      y: ny / d
+    };
+  },
+  lli4: function (p1, p2, p3, p4) {
+    const x1 = p1.x,
+          y1 = p1.y,
+          x2 = p2.x,
+          y2 = p2.y,
+          x3 = p3.x,
+          y3 = p3.y,
+          x4 = p4.x,
+          y4 = p4.y;
+    return utils.lli8(x1, y1, x2, y2, x3, y3, x4, y4);
+  },
+  lli: function (v1, v2) {
+    return utils.lli4(v1, v1.c, v2, v2.c);
+  },
+  makeline: function (p1, p2) {
+    const x1 = p1.x,
+          y1 = p1.y,
+          x2 = p2.x,
+          y2 = p2.y,
+          dx = (x2 - x1) / 3,
+          dy = (y2 - y1) / 3;
+    return new _bezier.Bezier(x1, y1, x1 + dx, y1 + dy, x1 + 2 * dx, y1 + 2 * dy, x2, y2);
+  },
+  findbbox: function (sections) {
+    let mx = nMax,
+        my = nMax,
+        MX = nMin,
+        MY = nMin;
+    sections.forEach(function (s) {
+      const bbox = s.bbox();
+      if (mx > bbox.x.min) mx = bbox.x.min;
+      if (my > bbox.y.min) my = bbox.y.min;
+      if (MX < bbox.x.max) MX = bbox.x.max;
+      if (MY < bbox.y.max) MY = bbox.y.max;
+    });
+    return {
+      x: {
+        min: mx,
+        mid: (mx + MX) / 2,
+        max: MX,
+        size: MX - mx
+      },
+      y: {
+        min: my,
+        mid: (my + MY) / 2,
+        max: MY,
+        size: MY - my
+      }
+    };
+  },
+  shapeintersections: function (s1, bbox1, s2, bbox2, curveIntersectionThreshold) {
+    if (!utils.bboxoverlap(bbox1, bbox2)) return [];
+    const intersections = [];
+    const a1 = [s1.startcap, s1.forward, s1.back, s1.endcap];
+    const a2 = [s2.startcap, s2.forward, s2.back, s2.endcap];
+    a1.forEach(function (l1) {
+      if (l1.virtual) return;
+      a2.forEach(function (l2) {
+        if (l2.virtual) return;
+        const iss = l1.intersects(l2, curveIntersectionThreshold);
+
+        if (iss.length > 0) {
+          iss.c1 = l1;
+          iss.c2 = l2;
+          iss.s1 = s1;
+          iss.s2 = s2;
+          intersections.push(iss);
+        }
+      });
+    });
+    return intersections;
+  },
+  makeshape: function (forward, back, curveIntersectionThreshold) {
+    const bpl = back.points.length;
+    const fpl = forward.points.length;
+    const start = utils.makeline(back.points[bpl - 1], forward.points[0]);
+    const end = utils.makeline(forward.points[fpl - 1], back.points[0]);
+    const shape = {
+      startcap: start,
+      forward: forward,
+      back: back,
+      endcap: end,
+      bbox: utils.findbbox([start, forward, back, end])
+    };
+
+    shape.intersections = function (s2) {
+      return utils.shapeintersections(shape, shape.bbox, s2, s2.bbox, curveIntersectionThreshold);
+    };
+
+    return shape;
+  },
+  getminmax: function (curve, d, list) {
+    if (!list) return {
+      min: 0,
+      max: 0
+    };
+    let min = nMax,
+        max = nMin,
+        t,
+        c;
+
+    if (list.indexOf(0) === -1) {
+      list = [0].concat(list);
+    }
+
+    if (list.indexOf(1) === -1) {
+      list.push(1);
+    }
+
+    for (let i = 0, len = list.length; i < len; i++) {
+      t = list[i];
+      c = curve.get(t);
+
+      if (c[d] < min) {
+        min = c[d];
+      }
+
+      if (c[d] > max) {
+        max = c[d];
+      }
+    }
+
+    return {
+      min: min,
+      mid: (min + max) / 2,
+      max: max,
+      size: max - min
+    };
+  },
+  align: function (points, line) {
+    const tx = line.p1.x,
+          ty = line.p1.y,
+          a = -atan2(line.p2.y - ty, line.p2.x - tx),
+          d = function (v) {
+      return {
+        x: (v.x - tx) * cos(a) - (v.y - ty) * sin(a),
+        y: (v.x - tx) * sin(a) + (v.y - ty) * cos(a)
+      };
+    };
+
+    return points.map(d);
+  },
+  roots: function (points, line) {
+    line = line || {
+      p1: {
+        x: 0,
+        y: 0
+      },
+      p2: {
+        x: 1,
+        y: 0
+      }
+    };
+    const order = points.length - 1;
+    const aligned = utils.align(points, line);
+
+    const reduce = function (t) {
+      return 0 <= t && t <= 1;
+    };
+
+    if (order === 2) {
+      const a = aligned[0].y,
+            b = aligned[1].y,
+            c = aligned[2].y,
+            d = a - 2 * b + c;
+
+      if (d !== 0) {
+        const m1 = -sqrt(b * b - a * c),
+              m2 = -a + b,
+              v1 = -(m1 + m2) / d,
+              v2 = -(-m1 + m2) / d;
+        return [v1, v2].filter(reduce);
+      } else if (b !== c && d === 0) {
+        return [(2 * b - c) / (2 * b - 2 * c)].filter(reduce);
+      }
+
+      return [];
+    } // see http://www.trans4mind.com/personal_development/mathematics/polynomials/cubicAlgebra.htm
+
+
+    const pa = aligned[0].y,
+          pb = aligned[1].y,
+          pc = aligned[2].y,
+          pd = aligned[3].y;
+    let d = -pa + 3 * pb - 3 * pc + pd,
+        a = 3 * pa - 6 * pb + 3 * pc,
+        b = -3 * pa + 3 * pb,
+        c = pa;
+
+    if (utils.approximately(d, 0)) {
+      // this is not a cubic curve.
+      if (utils.approximately(a, 0)) {
+        // in fact, this is not a quadratic curve either.
+        if (utils.approximately(b, 0)) {
+          // in fact in fact, there are no solutions.
+          return [];
+        } // linear solution:
+
+
+        return [-c / b].filter(reduce);
+      } // quadratic solution:
+
+
+      const q = sqrt(b * b - 4 * a * c),
+            a2 = 2 * a;
+      return [(q - b) / a2, (-b - q) / a2].filter(reduce);
+    } // at this point, we know we need a cubic solution:
+
+
+    a /= d;
+    b /= d;
+    c /= d;
+    const p = (3 * b - a * a) / 3,
+          p3 = p / 3,
+          q = (2 * a * a * a - 9 * a * b + 27 * c) / 27,
+          q2 = q / 2,
+          discriminant = q2 * q2 + p3 * p3 * p3;
+    let u1, v1, x1, x2, x3;
+
+    if (discriminant < 0) {
+      const mp3 = -p / 3,
+            mp33 = mp3 * mp3 * mp3,
+            r = sqrt(mp33),
+            t = -q / (2 * r),
+            cosphi = t < -1 ? -1 : t > 1 ? 1 : t,
+            phi = acos(cosphi),
+            crtr = crt(r),
+            t1 = 2 * crtr;
+      x1 = t1 * cos(phi / 3) - a / 3;
+      x2 = t1 * cos((phi + tau) / 3) - a / 3;
+      x3 = t1 * cos((phi + 2 * tau) / 3) - a / 3;
+      return [x1, x2, x3].filter(reduce);
+    } else if (discriminant === 0) {
+      u1 = q2 < 0 ? crt(-q2) : -crt(q2);
+      x1 = 2 * u1 - a / 3;
+      x2 = -u1 - a / 3;
+      return [x1, x2].filter(reduce);
+    } else {
+      const sd = sqrt(discriminant);
+      u1 = crt(-q2 + sd);
+      v1 = crt(q2 + sd);
+      return [u1 - v1 - a / 3].filter(reduce);
+    }
+  },
+  droots: function (p) {
+    // quadratic roots are easy
+    if (p.length === 3) {
+      const a = p[0],
+            b = p[1],
+            c = p[2],
+            d = a - 2 * b + c;
+
+      if (d !== 0) {
+        const m1 = -sqrt(b * b - a * c),
+              m2 = -a + b,
+              v1 = -(m1 + m2) / d,
+              v2 = -(-m1 + m2) / d;
+        return [v1, v2];
+      } else if (b !== c && d === 0) {
+        return [(2 * b - c) / (2 * (b - c))];
+      }
+
+      return [];
+    } // linear roots are even easier
+
+
+    if (p.length === 2) {
+      const a = p[0],
+            b = p[1];
+
+      if (a !== b) {
+        return [a / (a - b)];
+      }
+
+      return [];
+    }
+
+    return [];
+  },
+  curvature: function (t, d1, d2, _3d, kOnly) {
+    let num,
+        dnm,
+        adk,
+        dk,
+        k = 0,
+        r = 0; //
+    // We're using the following formula for curvature:
+    //
+    //              x'y" - y'x"
+    //   k(t) = ------------------
+    //           (x'² + y'²)^(3/2)
+    //
+    // from https://en.wikipedia.org/wiki/Radius_of_curvature#Definition
+    //
+    // With it corresponding 3D counterpart:
+    //
+    //          sqrt( (y'z" - y"z')² + (z'x" - z"x')² + (x'y" - x"y')²)
+    //   k(t) = -------------------------------------------------------
+    //                     (x'² + y'² + z'²)^(3/2)
+    //
+
+    const d = utils.compute(t, d1);
+    const dd = utils.compute(t, d2);
+    const qdsum = d.x * d.x + d.y * d.y;
+
+    if (_3d) {
+      num = sqrt(pow(d.y * dd.z - dd.y * d.z, 2) + pow(d.z * dd.x - dd.z * d.x, 2) + pow(d.x * dd.y - dd.x * d.y, 2));
+      dnm = pow(qdsum + d.z * d.z, 3 / 2);
+    } else {
+      num = d.x * dd.y - d.y * dd.x;
+      dnm = pow(qdsum, 3 / 2);
+    }
+
+    if (num === 0 || dnm === 0) {
+      return {
+        k: 0,
+        r: 0
+      };
+    }
+
+    k = num / dnm;
+    r = dnm / num; // We're also computing the derivative of kappa, because
+    // there is value in knowing the rate of change for the
+    // curvature along the curve. And we're just going to
+    // ballpark it based on an epsilon.
+
+    if (!kOnly) {
+      // compute k'(t) based on the interval before, and after it,
+      // to at least try to not introduce forward/backward pass bias.
+      const pk = utils.curvature(t - 0.001, d1, d2, _3d, true).k;
+      const nk = utils.curvature(t + 0.001, d1, d2, _3d, true).k;
+      dk = (nk - k + (k - pk)) / 2;
+      adk = (abs(nk - k) + abs(k - pk)) / 2;
+    }
+
+    return {
+      k: k,
+      r: r,
+      dk: dk,
+      adk: adk
+    };
+  },
+  inflections: function (points) {
+    if (points.length < 4) return []; // FIXME: TODO: add in inflection abstraction for quartic+ curves?
+
+    const p = utils.align(points, {
+      p1: points[0],
+      p2: points.slice(-1)[0]
+    }),
+          a = p[2].x * p[1].y,
+          b = p[3].x * p[1].y,
+          c = p[1].x * p[2].y,
+          d = p[3].x * p[2].y,
+          v1 = 18 * (-3 * a + 2 * b + 3 * c - d),
+          v2 = 18 * (3 * a - b - 3 * c),
+          v3 = 18 * (c - a);
+
+    if (utils.approximately(v1, 0)) {
+      if (!utils.approximately(v2, 0)) {
+        let t = -v3 / v2;
+        if (0 <= t && t <= 1) return [t];
+      }
+
+      return [];
+    }
+
+    const trm = v2 * v2 - 4 * v1 * v3,
+          sq = Math.sqrt(trm),
+          d2 = 2 * v1;
+    if (utils.approximately(d2, 0)) return [];
+    return [(sq - v2) / d2, -(v2 + sq) / d2].filter(function (r) {
+      return 0 <= r && r <= 1;
+    });
+  },
+  bboxoverlap: function (b1, b2) {
+    const dims = ["x", "y"],
+          len = dims.length;
+
+    for (let i = 0, dim, l, t, d; i < len; i++) {
+      dim = dims[i];
+      l = b1[dim].mid;
+      t = b2[dim].mid;
+      d = (b1[dim].size + b2[dim].size) / 2;
+      if (abs(l - t) >= d) return false;
+    }
+
+    return true;
+  },
+  expandbox: function (bbox, _bbox) {
+    if (_bbox.x.min < bbox.x.min) {
+      bbox.x.min = _bbox.x.min;
+    }
+
+    if (_bbox.y.min < bbox.y.min) {
+      bbox.y.min = _bbox.y.min;
+    }
+
+    if (_bbox.z && _bbox.z.min < bbox.z.min) {
+      bbox.z.min = _bbox.z.min;
+    }
+
+    if (_bbox.x.max > bbox.x.max) {
+      bbox.x.max = _bbox.x.max;
+    }
+
+    if (_bbox.y.max > bbox.y.max) {
+      bbox.y.max = _bbox.y.max;
+    }
+
+    if (_bbox.z && _bbox.z.max > bbox.z.max) {
+      bbox.z.max = _bbox.z.max;
+    }
+
+    bbox.x.mid = (bbox.x.min + bbox.x.max) / 2;
+    bbox.y.mid = (bbox.y.min + bbox.y.max) / 2;
+
+    if (bbox.z) {
+      bbox.z.mid = (bbox.z.min + bbox.z.max) / 2;
+    }
+
+    bbox.x.size = bbox.x.max - bbox.x.min;
+    bbox.y.size = bbox.y.max - bbox.y.min;
+
+    if (bbox.z) {
+      bbox.z.size = bbox.z.max - bbox.z.min;
+    }
+  },
+  pairiteration: function (c1, c2, curveIntersectionThreshold) {
+    const c1b = c1.bbox(),
+          c2b = c2.bbox(),
+          r = 100000,
+          threshold = curveIntersectionThreshold || 0.5;
+
+    if (c1b.x.size + c1b.y.size < threshold && c2b.x.size + c2b.y.size < threshold) {
+      return [(r * (c1._t1 + c1._t2) / 2 | 0) / r + "/" + (r * (c2._t1 + c2._t2) / 2 | 0) / r];
+    }
+
+    let cc1 = c1.split(0.5),
+        cc2 = c2.split(0.5),
+        pairs = [{
+      left: cc1.left,
+      right: cc2.left
+    }, {
+      left: cc1.left,
+      right: cc2.right
+    }, {
+      left: cc1.right,
+      right: cc2.right
+    }, {
+      left: cc1.right,
+      right: cc2.left
+    }];
+    pairs = pairs.filter(function (pair) {
+      return utils.bboxoverlap(pair.left.bbox(), pair.right.bbox());
+    });
+    let results = [];
+    if (pairs.length === 0) return results;
+    pairs.forEach(function (pair) {
+      results = results.concat(utils.pairiteration(pair.left, pair.right, threshold));
+    });
+    results = results.filter(function (v, i) {
+      return results.indexOf(v) === i;
+    });
+    return results;
+  },
+  getccenter: function (p1, p2, p3) {
+    const dx1 = p2.x - p1.x,
+          dy1 = p2.y - p1.y,
+          dx2 = p3.x - p2.x,
+          dy2 = p3.y - p2.y,
+          dx1p = dx1 * cos(quart) - dy1 * sin(quart),
+          dy1p = dx1 * sin(quart) + dy1 * cos(quart),
+          dx2p = dx2 * cos(quart) - dy2 * sin(quart),
+          dy2p = dx2 * sin(quart) + dy2 * cos(quart),
+          // chord midpoints
+    mx1 = (p1.x + p2.x) / 2,
+          my1 = (p1.y + p2.y) / 2,
+          mx2 = (p2.x + p3.x) / 2,
+          my2 = (p2.y + p3.y) / 2,
+          // midpoint offsets
+    mx1n = mx1 + dx1p,
+          my1n = my1 + dy1p,
+          mx2n = mx2 + dx2p,
+          my2n = my2 + dy2p,
+          // intersection of these lines:
+    arc = utils.lli8(mx1, my1, mx1n, my1n, mx2, my2, mx2n, my2n),
+          r = utils.dist(arc, p1); // arc start/end values, over mid point:
+
+    let s = atan2(p1.y - arc.y, p1.x - arc.x),
+        m = atan2(p2.y - arc.y, p2.x - arc.x),
+        e = atan2(p3.y - arc.y, p3.x - arc.x),
+        _; // determine arc direction (cw/ccw correction)
+
+
+    if (s < e) {
+      // if s<m<e, arc(s, e)
+      // if m<s<e, arc(e, s + tau)
+      // if s<e<m, arc(e, s + tau)
+      if (s > m || m > e) {
+        s += tau;
+      }
+
+      if (s > e) {
+        _ = e;
+        e = s;
+        s = _;
+      }
+    } else {
+      // if e<m<s, arc(e, s)
+      // if m<e<s, arc(s, e + tau)
+      // if e<s<m, arc(s, e + tau)
+      if (e < m && m < s) {
+        _ = e;
+        e = s;
+        s = _;
+      } else {
+        e += tau;
+      }
+    } // assign and done.
+
+
+    arc.s = s;
+    arc.e = e;
+    arc.r = r;
+    return arc;
+  },
+  numberSort: function (a, b) {
+    return a - b;
+  }
+};
+exports.utils = utils;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,499 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/cli": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.12.1.tgz",
+      "integrity": "sha512-eRJREyrfAJ2r42Iaxe8h3v6yyj1wu9OyosaUHW6UImjGf9ahGL9nsFNh7OCopvtcPL8WnEo7tp78wrZaZ6vG9g==",
+      "dev": true,
+      "requires": {
+        "@nicolo-ribaudo/chokidar-2": "^2.1.8",
+        "chokidar": "^3.4.0",
+        "commander": "^4.0.1",
+        "convert-source-map": "^1.1.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.0.0",
+        "lodash": "^4.17.19",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "chokidar": {
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+          "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.2",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.5.0"
+          }
+        },
+        "readdirp": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+          "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        }
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "@babel/core": {
+      "version": "7.12.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.3.tgz",
+      "integrity": "sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.12.1",
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helpers": "^7.12.1",
+        "@babel/parser": "^7.12.3",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.19",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
+      "integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.5",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+      "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
+      "integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.1"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+      "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.5"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+      "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-replace-supers": "^7.12.1",
+        "@babel/helper-simple-access": "^7.12.1",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
+        "lodash": "^4.17.19"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+      "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+      "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+      "dev": true
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
+      "integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.12.1",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/traverse": "^7.12.5",
+        "@babel/types": "^7.12.5"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+      "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.1"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+      "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.11.0"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
+      "integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.12.5",
+        "@babel/types": "^7.12.5"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
+      "integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==",
+      "dev": true
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.1.tgz",
+      "integrity": "sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-simple-access": "^7.12.1",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/template": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+      "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/parser": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
+      "integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.12.5",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/parser": "^7.12.5",
+        "@babel/types": "^7.12.5",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.12.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
+      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "lodash": "^4.17.19",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@nicolo-ribaudo/chokidar-2": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8.tgz",
+      "integrity": "sha512-FohwULwAebCUKi/akMFyGi7jfc7JXTeMHzKxuP3umRd9mK/2Y7/SMBSI2jX+YLopPXi+PF9l307NmpfxTdCegA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chokidar": "2.1.8"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
+          }
+        },
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+          "dev": true,
+          "optional": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "dev": true,
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true,
+          "optional": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -44,6 +537,34 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true,
+      "optional": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true,
+      "optional": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true,
+      "optional": true
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true,
+      "optional": true
+    },
     "array.prototype.map": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.2.tgz",
@@ -62,11 +583,101 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true,
+      "optional": true
+    },
+    "async-each": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true,
+      "optional": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true,
+      "optional": true
+    },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
     },
     "binary-extensions": {
       "version": "2.1.0",
@@ -98,6 +709,24 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
     },
     "camelcase": {
       "version": "5.3.1",
@@ -158,6 +787,31 @@
         "readdirp": "~3.3.0"
       }
     },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -197,6 +851,17 @@
         }
       }
     },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -212,11 +877,55 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true,
+      "optional": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true,
+      "optional": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true,
+      "optional": true
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -246,6 +955,13 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true,
+      "optional": true
+    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -262,6 +978,51 @@
       "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
       }
     },
     "diff": {
@@ -348,6 +1109,155 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -376,6 +1286,29 @@
         "is-buffer": "~2.0.3"
       }
     },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true,
+      "optional": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -395,6 +1328,12 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -406,6 +1345,13 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true,
+      "optional": true
     },
     "glob": {
       "version": "7.1.6",
@@ -429,6 +1375,12 @@
       "requires": {
         "is-glob": "^4.0.1"
       }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.4",
@@ -463,6 +1415,70 @@
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true,
+          "optional": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -490,6 +1506,35 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true,
+          "optional": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
     },
     "is-arguments": {
       "version": "1.0.4",
@@ -524,11 +1569,68 @@
       "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
       "dev": true
     },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true,
+          "optional": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "dev": true
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true,
+      "optional": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -569,6 +1671,16 @@
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
     "is-regex": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
@@ -599,6 +1711,13 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "optional": true
+    },
     "isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -610,6 +1729,13 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true,
+      "optional": true
     },
     "iterate-iterator": {
       "version": "1.0.1",
@@ -627,6 +1753,12 @@
         "iterate-iterator": "^1.0.1"
       }
     },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
     "js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -637,11 +1769,33 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
+    },
+    "json5": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "optional": true
     },
     "load-json-file": {
       "version": "4.0.0",
@@ -664,6 +1818,12 @@
         "p-locate": "^4.1.0"
       }
     },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
+    },
     "log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
@@ -673,11 +1833,166 @@
         "chalk": "^2.4.2"
       }
     },
+    "make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "requires": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true,
+      "optional": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
     "memorystream": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
       "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
       "dev": true
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true,
+          "optional": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -686,6 +2001,35 @@
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
       }
     },
     "mocha": {
@@ -753,6 +2097,26 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -794,6 +2158,47 @@
         "string.prototype.padend": "^3.0.0"
       }
     },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true,
+          "optional": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
@@ -806,6 +2211,16 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
     },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
     "object.assign": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
@@ -816,6 +2231,16 @@
         "function-bind": "^1.1.1",
         "has-symbols": "^1.0.0",
         "object-keys": "^1.0.11"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "isobject": "^3.0.1"
       }
     },
     "once": {
@@ -860,6 +2285,20 @@
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
       }
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true,
+      "optional": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true,
+      "optional": true
     },
     "path-exists": {
       "version": "4.0.0",
@@ -918,11 +2357,25 @@
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true,
+      "optional": true
+    },
     "prettier": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
       "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "optional": true
     },
     "promise.allsettled": {
       "version": "1.0.2",
@@ -957,6 +2410,38 @@
         "path-type": "^3.0.0"
       }
     },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true,
+          "optional": true
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "readdirp": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
@@ -965,6 +2450,38 @@
       "requires": {
         "picomatch": "^2.0.7"
       }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true,
+      "optional": true
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "dev": true,
+      "optional": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true,
+      "optional": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -987,6 +2504,20 @@
         "path-parse": "^1.0.6"
       }
     },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true,
+      "optional": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "optional": true
+    },
     "rollup": {
       "version": "2.32.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.32.1.tgz",
@@ -1001,6 +2532,16 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
     },
     "semver": {
       "version": "5.7.1",
@@ -1023,6 +2564,31 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -1043,6 +2609,180 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
+    },
+    "slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true,
+          "optional": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true,
+      "optional": true
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -1076,11 +2816,44 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
     },
     "string-width": {
       "version": "2.1.1",
@@ -1122,6 +2895,25 @@
         "es-abstract": "^1.17.5"
       }
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -1152,6 +2944,54 @@
         "has-flag": "^3.0.0"
       }
     },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true,
+          "optional": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1166,6 +3006,98 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
+    },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "upath": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "dev": true,
+      "optional": true
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true,
+      "optional": true
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true,
+      "optional": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true,
+      "optional": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "curves"
   ],
   "scripts": {
-    "build": "run-s build:docs build:dist build:cjs",
-    "build:base": "rollup ./lib/bezier.js --format esm --file ",
-    "build:docs": "npm run build:base -- ./docs/js/bezier.js",
-    "build:dist": "npm run build:base -- ./dist/bezier.js",
+    "build": "run-s build:*",
+    "rollup": "rollup ./lib/bezier.js --format esm --file ",
+    "build:docs": "npm run rollup -- ./docs/js/bezier.js",
+    "build:dist": "npm run rollup -- ./dist/bezier.js",
     "build:cjs": "babel --plugins @babel/plugin-transform-modules-commonjs lib --out-dir dist/cjs",
     "lint:lib": "prettier ./lib/**/*.js --write",
     "lint:test": "prettier ./test/**/*.js --write",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "3.1.0",
   "author": "Pomax",
   "description": "A javascript library for working with Bezier curves",
-  "main": "./lib/bezier.js",
   "type": "module",
+  "module": "./lib/bezier.js",
+  "main": "./dist/cjs/bezier.js",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Pomax/bezierjs/issues"
@@ -19,17 +20,21 @@
     "curves"
   ],
   "scripts": {
-    "rollup": "run-s rollup:docs rollup:dist",
-    "rollup:base": "rollup ./lib/bezier.js --format esm --file ",
-    "rollup:docs": "npm run rollup:base -- ./docs/js/bezier.js",
-    "rollup:dist": "npm run rollup:base -- ./dist/bezier.js",
+    "build": "run-s build:docs build:dist build:cjs",
+    "build:base": "rollup ./lib/bezier.js --format esm --file ",
+    "build:docs": "npm run build:base -- ./docs/js/bezier.js",
+    "build:dist": "npm run build:base -- ./dist/bezier.js",
+    "build:cjs": "babel --plugins @babel/plugin-transform-modules-commonjs lib --out-dir dist/cjs",
     "lint:lib": "prettier ./lib/**/*.js --write",
     "lint:test": "prettier ./test/**/*.js --write",
     "mocha": "mocha test/**/*.js",
-    "test": "npm start && npm run rollup",
+    "test": "npm start && npm run build",
     "start": "run-s lint:* mocha"
   },
   "devDependencies": {
+    "@babel/cli": "^7.12.1",
+    "@babel/core": "^7.12.3",
+    "@babel/plugin-transform-modules-commonjs": "^7.12.1",
     "chai": "^4.2.0",
     "chai-stats": "^0.3.0",
     "mocha": "^8.1.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Pomax",
   "description": "A javascript library for working with Bezier curves",
   "type": "module",
-  "module": "./lib/bezier.js",
+  "exports": "./lib/bezier.js",
   "main": "./dist/cjs/bezier.js",
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A javascript library for working with Bezier curves",
   "type": "module",
   "exports": "./lib/bezier.js",
-  "main": "./dist/cjs/bezier.js",
+  "main": "./dist/bezier.common.js",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Pomax/bezierjs/issues"
@@ -24,7 +24,7 @@
     "rollup": "rollup ./lib/bezier.js --format esm --file ",
     "build:docs": "npm run rollup -- ./docs/js/bezier.js",
     "build:dist": "npm run rollup -- ./dist/bezier.js",
-    "build:cjs": "babel --plugins @babel/plugin-transform-modules-commonjs lib --out-dir dist/cjs",
+    "build:cjs": "babel --plugins @babel/plugin-transform-modules-commonjs dist/bezier.js --out-file dist/bezier.common.js",
     "lint:lib": "prettier ./lib/**/*.js --write",
     "lint:test": "prettier ./test/**/*.js --write",
     "mocha": "mocha test/**/*.js",


### PR DESCRIPTION
Hybrid cjs/esm package
- Adds a babel transform for creating a commonjs version of the source
- Sets "exports" field for esm https://nodejs.org/api/packages.html#packages_package_entry_points
- Sets fallback "main" field for cjs

Fixes https://github.com/Pomax/bezierjs/issues/137

QA
- tests pass locally on node v12
- correctly imports esm source on node v12
- correctly imports cjs source in browserify
- confirmed fixes [upstream issue](https://github.com/vasturiano/force-graph/issues/152) in `force-graph`