### PR TITLE
Fix derivative calculations for 3D Bezier curves

### DIFF
--- a/src/bezier.js
+++ b/src/bezier.js
@@ -333,11 +333,11 @@ class Bezier {
   }
 
   derivative(t) {
-    return utils.compute(t, this.dpoints[0]);
+    return utils.compute(t, this.dpoints[0], this._3d);
   }
 
   dderivative(t) {
-    return utils.compute(t, this.dpoints[1]);
+    return utils.compute(t, this.dpoints[1], this._3d);
   }
 
   align() {


### PR DESCRIPTION
This PR fixes the derivative calculations for the 3D case; before this commit, the `_3d` private flag was not passed to `utils.compute()` for the derivative calculations, therefore the result always contained the first two coordinates only.