### PR TITLE
Fix: lerp() for 3D points when z is 0

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -288,7 +288,7 @@ const utils = {
       x: v1.x + r * (v2.x - v1.x),
       y: v1.y + r * (v2.y - v1.y),
     };
-    if (!!v1.z && !!v2.z) {
+    if (v1.z !== undefined && v2.z !== undefined) {
       ret.z = v1.z + r * (v2.z - v1.z);
     }
     return ret;


### PR DESCRIPTION
This PR fixes the `lerp` function when the passed coordinates are 3D but the `z` values are zero.

I encountered this error while trying to split a 3D bezier.
I'll explain it using two cases.

### 1.  When `z` is 1 (non-zero), it works perfectly fine
```
bezier1 = new Bezier({x:0,y:0,z:1}, {x:5,y:5,z:1}, {x:0,y:10,z:1});
bezier1.split(0.5);
```
![image](https://user-images.githubusercontent.com/17798178/116652449-d0ee3400-a9a2-11eb-97e0-27cce9fd530c.png)


### 2.  When `z` is 0, it gives some `undefined` values
```
bezier2 = new Bezier({x:0,y:0,z:0}, {x:5,y:5,z:0}, {x:0,y:10,z:0});
bezier2.split(0.5);
```
![image](https://user-images.githubusercontent.com/17798178/116652497-eb281200-a9a2-11eb-88be-eadaeb9bc790.png)


Upon a bit of debugging, I found out that the `lerp` function in `utils` checks if a point is 2D or 3D using something like
```
if (!!v1.z  && !!v2.z) {
      ret.z = v1.z + r * (v2.z - v1.z);
}
```
But when `v1.z` is available and zero, the condition fails and it does not go inside the if block. Thus, it's been updated to:
```
if (v1.z !== undefined && v2.z !== undefined) {
      ret.z = v1.z + r * (v2.z - v1.z);
}
```