### PR TITLE
feat(): `intersectsLine` line type

### DIFF
--- a/src/bezier.js
+++ b/src/bezier.js
@@ -848,14 +848,32 @@ class Bezier {
   }
 
   lineIntersects(line) {
-    const mx = min(line.p1.x, line.p2.x),
-      my = min(line.p1.y, line.p2.y),
-      MX = max(line.p1.x, line.p2.x),
-      MY = max(line.p1.y, line.p2.y);
-    return utils.roots(this.points, line).filter((t) => {
-      var p = this.get(t);
-      return utils.between(p.x, mx, MX) && utils.between(p.y, my, MY);
-    });
+    const roots = utils.roots(this.points, line);
+
+    if (line.type === "line") {
+      return roots;
+    } else if (line.type === "ray") {
+      const vx = line.p2.x - line.p1.x;
+      const vy = line.p2.y - line.p1.y;
+      return roots.filter((t) => {
+        const p = this.get(t);
+        const dx = p.x - line.p1.x;
+        const dy = p.y - line.p1.y;
+        return (
+          (dx === 0 && dy === 0) ||
+          (Math.sign(dx) === Math.sign(vx) && Math.sign(dy) === Math.sign(vy))
+        );
+      });
+    } else {
+      const mx = min(line.p1.x, line.p2.x),
+        my = min(line.p1.y, line.p2.y),
+        MX = max(line.p1.x, line.p2.x),
+        MY = max(line.p1.y, line.p2.y);
+      return roots.filter((t) => {
+        const p = this.get(t);
+        return utils.between(p.x, mx, MX) && utils.between(p.y, my, MY);
+      });
+    }
   }
 
   selfintersects(curveIntersectionThreshold) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -513,14 +513,22 @@ const utils = {
   align: function (points, line) {
     const tx = line.p1.x,
       ty = line.p1.y,
-      a = -atan2(line.p2.y - ty, line.p2.x - tx),
-      d = function (v) {
-        return {
-          x: (v.x - tx) * cos(a) - (v.y - ty) * sin(a),
-          y: (v.x - tx) * sin(a) + (v.y - ty) * cos(a),
-        };
+      dx = line.p2.x - tx,
+      dy = line.p2.y - ty,
+      magnitude = sqrt(dx ** 2 + dy ** 2),
+      unitX = dx / magnitude,
+      unitY = dy / magnitude;
+
+    return points.map((p) => {
+      const x = p.x - tx;
+      const y = p.y - ty;
+      // Apply a basis change on x,y to align the x axis of the curve with the line,
+      // Zero point of the curve being `p1`
+      return {
+        x: unitX * x - unitY * y,
+        y: unitY * x + unitX * y,
       };
-    return points.map(d);
+    });
   },
 
   roots: function (points, line) {

--- a/test/functionality/intersection.test.js
+++ b/test/functionality/intersection.test.js
@@ -1,12 +1,44 @@
 import { Bezier } from "../../src/bezier.js";
 
 describe(`Intersection testing`, () => {
+  test.each(["line", "ray", "segment", undefined])(
+    `line(%s)/curve intersection`,
+    (type) => {
+      const b = new Bezier(76, 250, 77, 150, 220, 50);
+      const line = { p1: { x: 13, y: 140 }, p2: { x: 213, y: 140 }, type };
+      const intersections = b.intersects(line);
+
+      expect(intersections.length).toBe(1); // curve intersects horizontal
+      expect(intersections[0]).toBe(0.55); // curve intersects horizontal
+    }
+  );
+
   test(`line/curve intersection`, () => {
-    var b = new Bezier(76, 250, 77, 150, 220, 50);
-    var line = { p1: { x: 13, y: 140 }, p2: { x: 213, y: 140 } };
-    var intersections = b.intersects(line);
+    const b = new Bezier(76, 250, 77, 150, 220, 50);
+    const line = { p1: { x: 13, y: 140 }, p2: { x: 14, y: 140 }, type: "line" };
+    const line2 = {
+      p1: { x: 14, y: 140 },
+      p2: { x: 13, y: 140 },
+      type: "line",
+    };
+    const intersections = b.intersects(line);
+    const intersections2 = b.intersects(line2);
 
     expect(intersections.length).toBe(1); // curve intersects horizontal
     expect(intersections[0]).toBe(0.55); // curve intersects horizontal
+    expect(intersections2.length).toBe(1); // curve intersects horizontal
+    expect(intersections2[0]).toBe(0.55); // curve intersects horizontal
+  });
+
+  test(`ray/curve intersection`, () => {
+    const b = new Bezier(76, 250, 77, 150, 220, 50);
+    const line = { p1: { x: 13, y: 140 }, p2: { x: 14, y: 140 }, type: "ray" };
+    const line2 = { p1: { x: 14, y: 140 }, p2: { x: 13, y: 140 }, type: "ray" };
+    const intersections = b.intersects(line);
+    const intersections2 = b.intersects(line2);
+
+    expect(intersections.length).toBe(1); // curve intersects horizontal
+    expect(intersections[0]).toBe(0.55); // curve intersects horizontal
+    expect(intersections2.length).toBe(0); // curve intersects horizontal
   });
 });


### PR DESCRIPTION

## Motivation 
I have use cases in which I need to specify the line type (line, ray, segment) for different use cases, e.g. ray casting algorithm to determine if point is contained in a closed shape, segment for rect/bezier intersections and line for finding extreme points on the bezier that intersect without needs to get the hull/bbox

## Changes

I have changed to `lineIntersects` method to respect the 3 types of line, segment being the default value as it is currently.
```
bezier.lineIntersects({ p1, p2, type: 'ray' }) // ray from p1 to p2
```

The `line` case test I have added surfaced a bug in `roots` or at least a precision error that creates quite a substantial difference. I tried debugging it and saw that when I pass a line and a line pointing to the opposite direction the `aligned` method rotates the curve wrt the line and that is where the precision error originates.
I wonder if using a change basis calculation will fix this (I will try).
If not maybe consider sorting the line points so that the output is the same for both cases. 



I admire your work
Thanks for this great repo