### PR TITLE
Improve bezier.reduce() function

### DIFF
--- a/test/general/cubic.test.js
+++ b/test/general/cubic.test.js
@@ -55,6 +55,27 @@ describe(`Cubic bezier`, () => {
     });
   });
 
+  describe(`difficult intersection`, () => {
+    var tt1 = new Bezier(20.294698715209961, 20.116849899291992,
+        26.718513488769531, 28.516490936279297,
+        33.345268249511719, 37.4105110168457,
+        36.240531921386719,37.736736297607422);
+    var tt2 = new Bezier(43.967803955078125, 30.767040252685547,
+        43.967803955078125, 31.771089553833008,
+        35.013500213623047, 32.585041046142578,
+        23.967803955078125, 32.585041046142578);
+
+    test(`should find two intersections`, () => {
+      var intersections = tt1.intersects(tt2);
+      expect(intersections.length).toEqual(2);
+    });
+
+    test(`should find reduction`, () => {
+      var ttReduced = tt1.reduce();
+      expect(ttReduced.length).toEqual(4);
+    });
+  });
+
   describe(`from point set`, () => {
     const M = { x: 200 / 3, y: 100 / 3 };
     const pts = [{ x: 0, y: 0 }, M, { x: 100, y: 100 }];


### PR DESCRIPTION
For some bézier curve shapes, the default step size of 0.01 in the reduce function is too large to split the curve into simple segments. In this case, recursively call the function with a smaller step value.

Fixes #203 and potentially also some other issues.